### PR TITLE
Fixed reports wrong number of passed/failed tests [1234810]

### DIFF
--- a/src/test/test.sh
+++ b/src/test/test.sh
@@ -361,9 +361,9 @@ do
   PASS=$( echo $line | cut -d ':' -f 1)
   FAIL=$( echo $line | cut -d ':' -f 2 )
   SKIP=$( echo $line | cut -d ':' -f 3 )
-  TotalPassed=$(( $TotalPassed+$PASS ))
-  TotalFailed=$(( $TotalFailed+$FAIL ))
-  TotalSkipped=$(( $TotalSkipped+$SKIP ))
+  TotalPassed=$(( $PASS ))
+  TotalFailed=$(( $FAIL ))
+  TotalSkipped=$(( $SKIP))
 done < $SCOREFILE
 
 rm -rf $TIMEFILE* $SCOREFILE

--- a/src/test/testingTest.sh
+++ b/src/test/testingTest.sh
@@ -225,6 +225,22 @@ test_rlAssertGreaterOrEqual(){
 	assertParameters 'rlAssertGreaterOrEqual comment 10 10'
 }
 
+test_rlAssertLesser(){
+	assertGoodBad 'rlAssertLesser "comment" 1 999' 1 0
+	assertGoodBad 'rlAssertLesser "comment" -1 1' 1 0
+	assertGoodBad 'rlAssertLesser "comment" 1000 999' 0 1
+	assertGoodBad 'rlAssertLesser "comment" 100 10' 0 1
+	assertParameters 'rlAssertLesser comment -2 -1'
+}
+
+test_rlAssertLesserOrEqual(){
+	assertGoodBad 'rlAssertLesserOrEqual "comment" 1 999' 1 0
+	assertGoodBad 'rlAssertLesserOrEqual "comment" -1 1' 1 0
+	assertGoodBad 'rlAssertLesserOrEqual "comment" 1000 999' 0 1
+	assertGoodBad 'rlAssertLesserOrEqual "comment" 100 10' 0 1
+	assertParameters 'rlAssertLesserOrEqual comment 10 10'
+}
+
 test_rlRun(){
 	assertGoodBad 'rlRun /bin/true 0 comment' 1 0
 	assertGoodBad 'rlRun /bin/true 3 comment' 0 1

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -318,7 +318,7 @@ Integer value.
 
 =back
 
-Returns 0 and asserts PASS when C<value1 E<gt>= value2>.
+Returns 0 and asserts PASS when C<value1 E<ge>= value2>.
 
 =cut
 

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -327,6 +327,79 @@ rlAssertGreaterOrEqual() {
     return $?
 }
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlAssertLesser
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+: <<'=cut'
+=pod
+
+=head3 rlAssertLesser
+
+Assertion checking whether first parameter is lesser than the second one.
+
+    rlAssertLesser comment value1 value2
+
+=over
+
+=item comment
+
+Short test summary, e.g. "Test whether there are running more instances of program."
+
+=item value1
+
+Integer value.
+
+=item value2
+
+Integer value.
+
+=back
+
+Returns 0 and asserts PASS when C<value1 E<le> value2>.
+
+=cut
+
+rlAssertLesser() {
+    __INTERNAL_ConditionalAssert "$1" "$([ "$2" -le "$3" ]; echo $?)" "(Assert: \"$2\" should be lesser than \"$3\")"
+    return $?
+}
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlAssertLesserOrEqual
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+: <<'=cut'
+=pod
+
+=head3 rlAssertLesserOrEqual
+
+Assertion checking whether first parameter is lesser or equal to the second one.
+
+    rlAssertLesserOrEqual comment value1 value2
+
+=over
+
+=item comment
+
+Short test summary (e.g. "There should present at least one...")
+
+=item value1
+
+Integer value.
+
+=item value2
+
+Integer value.
+
+=back
+
+Returns 0 and asserts PASS when C<value1 E<le>= value2>.
+
+=cut
+
+rlAssertLesserOrEqual() {
+    __INTERNAL_ConditionalAssert "$1" "$([ "$2" -le "$3" ]; echo $?)" "(Assert: \"$2\" should be <= \"$3\")"
+    return $?
+}
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
``` bash
$ ./test.sh infrastructureTest.sh test_rlCheckMount
```
Was: 

``` bash 
...
 [ FAIL ] Testing test_rlCheckMount finished: 1 passed, 10 failed, 0 skipped
 [ FAIL ] Total summary: 2 passed, 20 failed, 0 skipped
```

Now:

``` bash
...
[ FAIL ] Testing test_rlCheckMount finished: 1 passed, 10 failed, 0 skipped
[ FAIL ] Total summary: 1 passed, 10 failed, 0 skipped
```
Fedora: `25`
beakerlib: `1.16`