### PR TITLE
Only call VERIFIER (*LibraryLoaded) if it exists, bz1460035

### DIFF
--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -444,7 +444,7 @@ rlImport() {
     }
 
     # Call the validation callback of the function
-    if ! eval $VERIFIER
+    if type -t $VERIFIER >/dev/null && ! eval $VERIFIER
     then
       rlLogError "rlImport: Import of library $library was not successful (callback failed)"
       RESULT=1


### PR DESCRIPTION
Verifier should not be mandatory.  If user did not define it, we'll
assume they don't care.