### PR TITLE
Fix for bz1234810 - wrong number of passed/failed tests

### DIFF
--- a/src/test/test.sh
+++ b/src/test/test.sh
@@ -345,29 +345,6 @@ rm -rf $BEAKERLIB_DIR
 
 # print summary
 echo
-for file in $( ls ${TIMEFILE}* 2>/dev/null )
-do
-    OLDTIMEFILE=".${file#$TIMEFILE.}-perf.old"
-    assertLog "${file#$TIMEFILE.} performance: $( cat $file )"
-    if [ -e $OLDTIMEFILE ]
-    then
-      assertLog "${file#$TIMEFILE.}   Was:       $( cat $OLDTIMEFILE )"
-    fi
-    cat $file > $OLDTIMEFILE
-done
-
-while read line
-do
-  PASS=$( echo $line | cut -d ':' -f 1)
-  FAIL=$( echo $line | cut -d ':' -f 2 )
-  SKIP=$( echo $line | cut -d ':' -f 3 )
-  TotalPassed=$(( $TotalPassed+$PASS ))
-  TotalFailed=$(( $TotalFailed+$FAIL ))
-  TotalSkipped=$(( $TotalSkipped+$SKIP ))
-done < $SCOREFILE
-
-rm -rf $TIMEFILE* $SCOREFILE
-
 if [ $TotalPassed -gt 0 -a $TotalFailed == 0 ]; then
     assertLog "Total summary: $TotalPassed passed, $TotalFailed failed, $TotalSkipped skipped\n" "PASS"
     exit 0

--- a/src/test/test.sh
+++ b/src/test/test.sh
@@ -145,7 +145,6 @@ assertEnd() {
         assertLog "Testing $name finished: No assserts run" "WARN"
     fi
 
-    printf "%i:%i:%i\n" $__INTERNAL_ASSERT_PASSED $__INTERNAL_ASSERT_FAILED $__INTERNAL_ASSERT_SKIPPED>> $SCOREFILE
 }
 
 
@@ -277,7 +276,7 @@ export TEST='beakerlib-unit-tests'
 export __INTERNAL_JOURNALIST="$BEAKERLIB/python/journalling.py"
 export __INTERNAL_STORAGE_BIN="$BEAKERLIB/python/bstor.py"
 export OUTPUTFILE=$(mktemp) # no-reboot
-export SCOREFILE=$(mktemp) # no-reboot
+
 rlJournalStart
 
 # check parameters for test list
@@ -345,6 +344,19 @@ rm -rf $BEAKERLIB_DIR
 
 # print summary
 echo
+
+for file in $( ls ${TIMEFILE}* 2>/dev/null )
+    do
+        OLDTIMEFILE=".${file#$TIMEFILE.}-perf.old"
+        assertLog "${file#$TIMEFILE.} performance: $( cat $file )"
+        if [ -e $OLDTIMEFILE ]
+            then
+            assertLog "${file#$TIMEFILE.}   Was:       $( cat $OLDTIMEFILE )"
+        fi
+        cat $file > $OLDTIMEFILE
+    done
+rm -rf $TIMEFILE*
+
 if [ $TotalPassed -gt 0 -a $TotalFailed == 0 ]; then
     assertLog "Total summary: $TotalPassed passed, $TotalFailed failed, $TotalSkipped skipped\n" "PASS"
     exit 0


### PR DESCRIPTION
The purpose of deleting that part of file is because it actually doubled `((TotalPassed++))` and `((TotalPassed++))`. 

Actual result:
```
$ ./test.sh test_rlAssertLesser
 [ INFO ] Testing test_rlAssertLesser
 [ PASS ] 1 good logged for 'rlAssertLesser "comment" 1 999'
 [ PASS ] 0 bad logged for 'rlAssertLesser "comment" 1 999'
 [ PASS ] 1 good logged for 'rlAssertLesser "comment" -1 1'
 [ PASS ] 0 bad logged for 'rlAssertLesser "comment" -1 1'
 [ PASS ] 0 good logged for 'rlAssertLesser "comment" 1000 999'
 [ PASS ] 1 bad logged for 'rlAssertLesser "comment" 1000 999'
 [ PASS ] 0 good logged for 'rlAssertLesser "comment" 100 10'
 [ PASS ] 1 bad logged for 'rlAssertLesser "comment" 100 10'
 [ PASS ] running 'rlAssertLesser comment -2 -1' (all parameters) must succeed
 [ PASS ] running just 'rlAssertLesser ' (missing parameters) must not succeed
 [ PASS ] running just 'rlAssertLesser comment ' (missing parameters) must not succeed
 [ PASS ] running just 'rlAssertLesser comment -2 ' (missing parameters) must not succeed
 [ PASS ] Testing test_rlAssertLesser finished: 12 passed, 0 failed, 0 skipped

 [ PASS ] Total summary: 12 passed, 0 failed,  skipped
```
