### PR TITLE
libraries.sh: add support for upstream beakerlib libraries

### DIFF
--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -173,6 +173,15 @@ __INTERNAL_rlLibrarySearch() {
     return
   fi
 
+  __INTERNAL_rlLibrarySearchInRoot "$COMPONENT" "$LIBRARY" "/usr/share/beakerlib-libraries"
+  if [ -n "$LIBFILE" ]
+  then
+    local VERSION="$(__INTERNAL_extractLibraryVersion "$LIBFILE" "$COMPONENT/$LIBRARY")"
+      VERSION=${VERSION:+", version '$VERSION'"}
+    rlLogInfo "rlImport: Found '$COMPONENT/$LIBRARY'$VERSION in /usr/share/beakerlib-libraries"
+    return
+  fi
+
   if [ -n "$__INTERNAL_TraverseRoot" ]
   then
     rlLogDebug "rlImport: Trying to find the library in directories above test"


### PR DESCRIPTION
We need to support the standard location of beakerlib-libraries in
upstream the same way we support it downstream.

Upstream beakerlib-libraries are here: https://pagure.io/beakerlib-libraries

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>