### PR TITLE
testing.sh: Make rlRun doc less ambiguous

### DIFF
--- a/src/testing.sh
+++ b/src/testing.sh
@@ -663,7 +663,7 @@ rlAssertNotDiffer() {
 Run command with optional comment and make sure its exit code
 matches expectations.
 
-    rlRun [-t] [-l] [-c] [-s] command [status[,status...]] [comment]
+    rlRun [-t] [-l] [-c] [-s] command [status[,status...] [comment]]
 
 =over
 


### PR DESCRIPTION
`rlRun` doc was a bit ambiguous and could be read as "both status and comment are optional and you can use one of them or both of them at the same time". That is obviously not true - if you want to provide a comment, you have to provide exit status first.

This patch makes intended usage clearer, hopefully.