### PR TITLE
virtualX.sh - various fixes and improvements

### DIFF
--- a/src/virtualX.sh
+++ b/src/virtualX.sh
@@ -114,7 +114,7 @@ function rlVirtXStartDisplay() {
     Xvfb :$Xdisplay -ac -screen 0 1600x1200x24 -fbdir /tmp/$Xid & # no-reboot
     local Xpid=$!
     sleep 3
-    if ! ps | grep $Xpid >/dev/null; then
+    if ! ps -p $Xpid >/dev/null; then
         rlLogDebug "rlVirtXStartDisplay: Virtual X failed to start"
         return 1
     else
@@ -249,11 +249,11 @@ function rlVirtualXStop() {
         rlLogDebug "rlVirtualXStop: Provide pid you want to kill"
         return 1
     fi
-    if ps | grep $Xpid >/dev/null; then
+    if ps -p $Xpid >/dev/null; then
         kill "$Xpid"
     fi
     sleep 2; # added by koca (some servers aren't so quick :))
-    if ! ps | grep $Xpid >/dev/null; then
+    if ! ps -p $Xpid >/dev/null; then
         rlLogDebug "rlVirtualXStop: Normal 'kill $Xpid' succeed"
     else
         rlLogWarning "rlVirtualXStop: I had to 'kill -9 $Xpid' (rc: $?) X server"
@@ -266,7 +266,7 @@ function rlVirtualXStop() {
             rm -f "/tmp/.X$Xdisplay-lock" # no-reboot
             sleep 1
         fi
-        if ps | grep $Xpid >/dev/null; then
+        if ps -p $Xpid >/dev/null; then
             rlLogDebug "rlVirtualXStop: I was not able to kill pid '$Xpid', sorry"
             return 2
         fi

--- a/src/virtualX.sh
+++ b/src/virtualX.sh
@@ -244,7 +244,7 @@ Returns 0 when the server is stopped successfully.
 function rlVirtualXStop() {
     local Xid=$( rlVirtXGetCorrectID "$1" )
     local Xpid=$( rlVirtXGetPid "$Xid" )
-    local Xdisplay=$( rlVirtualXGetDisplay "$1" )
+    local Xdisplay=$( rlVirtualXGetDisplay "$1" | sed "s/[^0-9]//g" )
     if [ -z "$Xpid" ]; then
         rlLogDebug "rlVirtualXStop: Provide pid you want to kill"
         return 1

--- a/src/virtualX.sh
+++ b/src/virtualX.sh
@@ -152,13 +152,17 @@ server.
 Start a virtual X server on a first free display. Tries only first
 N displays, so you can run out of them.
 
-    rlVirtualXStart name
+    rlVirtualXStart name [N]
 
 =over
 
 =item name
 
 String identifying the X server.
+
+=item N
+
+Maximum number of displays to try. Defaults to 3.
 
 =back
 
@@ -167,7 +171,7 @@ Returns 0 when the server is started successfully.
 =cut
 
 function rlVirtualXStart() {
-    local Xmax=3
+    local Xmax=${2:-3}
     local Xid=$( rlVirtXGetCorrectID "$1" )
     local Xdisplay=0
     for Xdisplay in $( seq 1 $Xmax ); do
@@ -177,7 +181,7 @@ function rlVirtualXStart() {
             return 0
         fi
     done
-    rlLogDebug "rlVirtualXStart: Was not able to start on displays from :1 to :Xmax"
+    rlLogDebug "rlVirtualXStart: Was not able to start on displays from :1 to :$Xmax"
     return 1
 }
 


### PR DESCRIPTION
Please merge `virtualx-fixes` branch. There are four commits that can be applied separately:

- Namespace Xvfb framebuffer directory, so `Xvfb`s running concurrently don't overwrite/remove each other files
- Make code related to `X${Xdisplay}-lock` actually work
- Verify that process with given PID is running by exact, instead of partial, match
- Let users specify how many displays they want to try before bailing out (defaults to 3)

See commit messages for details.