### PR TITLE
Nerf phase stats delimiter

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -601,7 +601,7 @@ rljClosePhase(){
     rlLogDebug "rljClosePhase: Phase $name closed"
     __INTERNAL_SET_TIMESTAMP
     local endtime="$__INTERNAL_TIMESTAMP"
-    __INTERNAL_LogText "________________________________________________________________________________"
+    __INTERNAL_LogText "............................................." LOG
     __INTERNAL_LogText "Duration: $((endtime - __INTERNAL_PHASE_STARTTIME))s" LOG
     __INTERNAL_LogText "Assertions: $__INTERNAL_PHASE_PASSED good, $__INTERNAL_PHASE_FAILED bad" LOG
     __INTERNAL_LogText "RESULT: $name" $result


### PR DESCRIPTION
Recent journal.sh rewrite has added delimiter between log lines from
within the line and phase closing stats added by `rljClosePhase()`.

While the visual delimiter is appreciated, it is a bit too "harsh":
journal uses mostly colons and whitespace for visual structuring, but
the new delimiter uses underscores, which are more prominent.  Also the
line with delimiter does not have severity/timestamp, whuich makes the
effect even stronger.  This breaks visual structure---especially for
logs with many smaller phases.

This commit replaces the new delimiter with one that is composed of dots
and includes severity/timestamp prefix---just like surrounding lines.
As a result, the delimiter blends in and phase looks more like a block,
while it's clear where the stats begin.