### PR TITLE
Make print calls python2 and python3 compatible.

### DIFF
--- a/src/python/daemonize.py
+++ b/src/python/daemonize.py
@@ -116,7 +116,7 @@ def daemonize(command, alias=None, pidfile=None, true_daemon=True, su=None, iore
 
 # argument parsing
 def error(msg):
-    print >> sys.stderr, "error: " + str(msg)
+    print("error: " + str(msg), file=sys.stderr)
     sys.exit(1)
 
 parser = OptionParser(usage='%prog [options] COMMAND')

--- a/src/python/journal-compare.py
+++ b/src/python/journal-compare.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
 
-# Copyright (c) 2006 Red Hat, Inc. All rights reserved. This copyrighted material 
+# Copyright (c) 2006 Red Hat, Inc. All rights reserved. This copyrighted material
 # is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2.
@@ -135,7 +135,7 @@ class TestSet:
 			try:
 				result_list.append(self.results[key].compare(other.results[key]))
 			except KeyError:
-				print "[WARN] Could not find corresponding test for: %s" % key
+				print("[WARN] Could not find corresponding test for: %s" % key)
 		return result_list
 
 try:
@@ -161,7 +161,7 @@ for i in walk_through:
 	new_type, new_name = new_phases[i].getAttribute("type"), new_phases[i].getAttribute("name")
 
 	if old_type == new_type and old_name == new_name:
-		print "Types match, so we are comparing phase %s of type %s" % (old_type, new_type)
+		print( "Types match, so we are comparing phase %s of type %s" % (old_type, new_type))
 		old_tests = TestSet()
 		new_tests = TestSet()
 		old_metrics = {}
@@ -179,20 +179,20 @@ for i in walk_through:
 				tolerance = float(metric.getAttribute("tolerance"))
 				metrics[key] = Metric(key, value, metric.getAttribute("type"), tolerance)
 
-		print "==== Actual compare ===="
-		print " * Metrics * "
+		print("==== Actual compare ====")
+		print(" * Metrics * ")
 		metric_results = []
 		for key in old_metrics.keys():
 			metric_results.append(old_metrics[key].compare(new_metrics[key]))
 		for metric in metric_results:
 			for message in metric.messages:
-				print "[%s] %s (%s)" % (metric.result, metric.name, message)
-		print " * Tests * "
+				print("[%s] %s (%s)" % (metric.result, metric.name, message))
+		print(" * Tests * ")
 		test_results = old_tests.compare(new_tests)
 		for test in test_results:
-			print "[%s] %s" % (test.result, test.name)
+			print("[%s] %s" % (test.result, test.name))
 			for message in test.messages:
-				print "\t - %s" % message
+				print("\t - %s" % message)
 
 	else:
-		print "We are not doing any compare, types dont match"
+		print("We are not doing any compare, types dont match")

--- a/src/python/rlMemAvg.py
+++ b/src/python/rlMemAvg.py
@@ -31,7 +31,7 @@ except ImportError:
   use_popen = True
 
 if len(sys.argv) < 2:
-  print 'syntax: rlMemAvg <command>'
+  print('syntax: rlMemAvg <command>')
   sys.exit(1)
 
 proglist = sys.argv[1:]
@@ -59,4 +59,4 @@ while True:
   if (use_sub and finish != None) or (use_popen and finish != -1):
     break
 
-print "%d" % (memsum/tick)
+print("%d" % (memsum/tick))

--- a/src/python/rlMemPeak.py
+++ b/src/python/rlMemPeak.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
 
-# Authors:  Petr Muller     <pmuller@redhat.com> 
+# Authors:  Petr Muller     <pmuller@redhat.com>
 #
 # Description: Prints a memory consumption peak of an executed program
 #
@@ -31,7 +31,7 @@ except ImportError:
   use_popen = True
 
 if len(sys.argv) < 2:
-  print 'syntax: rlMemPeak <command>'
+  print('syntax: rlMemPeak <command>')
   sys.exit(1)
 
 proglist = sys.argv[1:]
@@ -57,4 +57,4 @@ while True:
   if (use_sub and finish != None) or (use_popen and finish != -1):
     break
 
-print "%d" % (maxmem)
+print("%d" % (maxmem))

--- a/src/python/testwatcher.py
+++ b/src/python/testwatcher.py
@@ -105,12 +105,12 @@ else:
 ### HELPERS
 #
 def debug(msg):
-    print 'TESTWATCHER: '+msg
+    print('TESTWATCHER: '+msg)
     sys.stdout.flush()
 
 
 def fatal(msg):
-    print >> sys.stderr, 'TESTWATCHER fatal: '+msg
+    print('TESTWATCHER fatal: '+msg, file=sys.stderr)
     sys.stderr.flush()
     sys.exit(1)
 


### PR DESCRIPTION
Make the print calls python2 and python3 compatible
by adding parentheses to them in the python scripts.