### PR TITLE
Use /etc/os-release in rlGetDistro*()

### DIFF
--- a/src/logging.sh
+++ b/src/logging.sh
@@ -892,9 +892,17 @@ __rlGetDistroVersion() {
     echo "$version"
 }
 rlGetDistroRelease() {
+    __rlOsReleaseHasParam VERSION_ID && {
+        __rlGetOsReleaseParam VERSION_ID | grep -o '^[[:digit]]\+'
+        return 0
+    }
     __rlGetDistroVersion | sed "s/^\([0-9.]\+\)[^0-9.]\+.*$/\1/" | sed "s/6\.9[0-9]/7/" | cut -d '.' -f 1
 }
 rlGetDistroVariant() {
+    __rlOsReleaseHasParam VARIANT && {
+        __rlGetOsReleaseParam VARIANT
+        return 0
+    }
     VARIANT="$(__rlGetDistroVersion | sed "s/^[0-9.]\+\(.*\)$/\1/")"
     if [ -z "$VARIANT" ]; then
       rpm -q --qf="%{NAME}" --whatprovides redhat-release | cut -c 16- | sed 's/.*/\u&/'

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -852,8 +852,8 @@ __rlOsReleaseHasParam() {
     # contain parameter assignment.  Exit with one otherwise.
     #
     local param=$1
-    test -f /etc/os-release || return 1
-    grep -qE '^[[:space:]]*'"$param"'=' /etc/os-release
+    [[ -f /etc/os-release ]] || return 1
+    grep -qE "^\s*${param}=" /etc/os-release
 }
 __rlGetOsReleaseParam() {
     #
@@ -871,8 +871,8 @@ __rlGetOsReleaseParam() {
     local param=$1
     local code
     __rlOsReleaseHasParam "$param" || return 1
-    code='( . /etc/os-release; echo "$'"$param"'"; )'
-    rlLogDebug "__rlGetOsReleaseParam: Code used to read parameter: $code"
+    code='( . /etc/os-release; echo "${!param}"; )'
+    rlLogDebug "$FUNCNAME(): Code used to read parameter: $code, where \$param=$param"
     eval "$code"
 }
 __rlGetDistroVersion() {
@@ -888,12 +888,12 @@ __rlGetDistroVersion() {
     else
         version="unknown"
     fi
-    rlLogDebug "__rlGetDistroVersion: This is distribution version '$version'"
+    rlLogDebug "$FUNCNAME(): This is distribution version '$version'"
     echo "$version"
 }
 rlGetDistroRelease() {
     __rlOsReleaseHasParam VERSION_ID && {
-        __rlGetOsReleaseParam VERSION_ID | grep -o '^[[:digit]]\+'
+        __rlGetOsReleaseParam VERSION_ID | grep -oE '^[0-9]+'
         return 0
     }
     __rlGetDistroVersion | sed "s/^\([0-9.]\+\)[^0-9.]\+.*$/\1/" | sed "s/6\.9[0-9]/7/" | cut -d '.' -f 1

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -844,7 +844,7 @@ on the RHEL-5-Client you will get release 5 and variant Client.
 
 =cut
 
-__rlOsReleaseHasParam() {
+__INTERNAL_rlOsReleaseHasParam() {
     #
     # True if /etc/os-release defines parameter $1
     #
@@ -855,7 +855,7 @@ __rlOsReleaseHasParam() {
     [[ -f /etc/os-release ]] || return 1
     grep -qE "^\s*${param}=" /etc/os-release
 }
-__rlGetOsReleaseParam() {
+__INTERNAL_rlGetOsReleaseParam() {
     #
     # Print value of parameter $1 from /etc/os-release
     #
@@ -870,12 +870,12 @@ __rlGetOsReleaseParam() {
     #
     local param=$1
     local code
-    __rlOsReleaseHasParam "$param" || return 1
+    __INTERNAL_rlOsReleaseHasParam "$param" || return 1
     code='( . /etc/os-release; echo "${!param}"; )'
     rlLogDebug "$FUNCNAME(): Code used to read parameter: $code, where \$param=$param"
     eval "$code"
 }
-__rlGetDistroVersion() {
+__INTERNAL_rlGetDistroVersion() {
     local version=0
     if rpm -q redhat-release &>/dev/null; then
         version=$( rpm -q --qf="%{VERSION}" redhat-release )
@@ -892,18 +892,18 @@ __rlGetDistroVersion() {
     echo "$version"
 }
 rlGetDistroRelease() {
-    __rlOsReleaseHasParam VERSION_ID && {
-        __rlGetOsReleaseParam VERSION_ID | grep -oE '^[0-9]+'
+    __INTERNAL_rlOsReleaseHasParam VERSION_ID && {
+        __INTERNAL_rlGetOsReleaseParam VERSION_ID | grep -oE '^[0-9]+'
         return 0
     }
-    __rlGetDistroVersion | sed "s/^\([0-9.]\+\)[^0-9.]\+.*$/\1/" | sed "s/6\.9[0-9]/7/" | cut -d '.' -f 1
+    __INTERNAL_rlGetDistroVersion | sed "s/^\([0-9.]\+\)[^0-9.]\+.*$/\1/" | sed "s/6\.9[0-9]/7/" | cut -d '.' -f 1
 }
 rlGetDistroVariant() {
-    __rlOsReleaseHasParam VARIANT && {
-        __rlGetOsReleaseParam VARIANT
+    __INTERNAL_rlOsReleaseHasParam VARIANT && {
+        __INTERNAL_rlGetOsReleaseParam VARIANT
         return 0
     }
-    VARIANT="$(__rlGetDistroVersion | sed "s/^[0-9.]\+\(.*\)$/\1/")"
+    VARIANT="$(__INTERNAL_rlGetDistroVersion | sed "s/^[0-9.]\+\(.*\)$/\1/")"
     if [ -z "$VARIANT" ]; then
       rpm -q --qf="%{NAME}" --whatprovides redhat-release | cut -c 16- | sed 's/.*/\u&/'
     else

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -844,6 +844,37 @@ on the RHEL-5-Client you will get release 5 and variant Client.
 
 =cut
 
+__rlOsReleaseHasParam() {
+    #
+    # True if /etc/os-release defines parameter $1
+    #
+    # Exit with zero if the /etc/os-release file was found and it did
+    # contain parameter assignment.  Exit with one otherwise.
+    #
+    local param=$1
+    test -f /etc/os-release || return 1
+    grep -qE '^[[:space:]]*'"$param"'=' /etc/os-release
+}
+__rlGetOsReleaseParam() {
+    #
+    # Print value of parameter $1 from /etc/os-release
+    #
+    # Exit with one if the /etc/os-release file was not found or it did not
+    # contain the necessary parameter assignment.  Exit with zero if file
+    # exists and parameter was found (value of empty string is OL).
+    #
+    # Note that the parameter name is case-sensitive (and the well-known
+    # parameters have ALL_CAPS names).  The reading is performed by
+    # sourcing the file in subshell, and syntax errors are NOT checked
+    # for.
+    #
+    local param=$1
+    local code
+    __rlOsReleaseHasParam "$param" || return 1
+    code='( . /etc/os-release; echo "$'"$param"'"; )'
+    rlLogDebug "__rlGetOsReleaseParam: Code used to read parameter: $code"
+    eval "$code"
+}
 __rlGetDistroVersion() {
     local version=0
     if rpm -q redhat-release &>/dev/null; then


### PR DESCRIPTION
Modern distros now use /etc/os-release, which contains the data in easy-to-consume format.  In other words, if /etc/os-release is present (which it is on all current systemd-based distros), it's much much more reliable.

This PR adds:

 *  functions to consult this file,
 *  patch to have the `rlGetDistro*()` prefer this file as a source.