### PR TITLE
rpms.sh: fixed search url for src rpms

### DIFF
--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -671,7 +671,12 @@ __INTERNAL_rpmGetNextUrl() {
           ;;
         koji,nvra.rpm)
           rlLogDebug "$FUNCNAME(): get rpm info"
-          local rpm_info=$($__INTERNAL_WGET -O - "$base_url/search?match=exact&type=rpm&terms=$N-$V-$R.$A.rpm")
+          local rpm_info
+          if [[ -n "$source" ]]; then
+            rpm_info=$($__INTERNAL_WGET -O - "$base_url/search?match=exact&type=rpm&terms=$N-$V-$R.src.rpm")
+          else
+            rpm_info=$($__INTERNAL_WGET -O - "$base_url/search?match=exact&type=rpm&terms=$N-$V-$R.$A.rpm")
+          fi
           [[ $? -ne 0 || -z "$rpm_info" ]] && {
             rlLogError "could not download rpm information"
             let res++


### PR DESCRIPTION
This PR fixes url (koji) to search source rpms (used as part fallback for functions to download rpms). Issue can be seen when BEAKERLIB_rpm_fetch_base_url is changed to invalid one (to simulate need for fallback) and then one of following commands is used to download source rpm:

rlFetchSrcForInstalled [pkg]
rlRpmDownload --source [N] [V] [R]

( searched package name then ends with ..rpm instead of .src.rpm )
