### PR TITLE
TESTPACKAGE variable to force package name

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -762,6 +762,8 @@ __INTERNAL_DeterminePackage(){
         else
             package="$PACKAGE"
         fi
+    elif [[ -n "$TESTPACKAGE" ]]; then
+        package="$TESTPACKAGE"
     else
         local arrPac=(${TEST//// })
         package=${arrPac[1]}


### PR DESCRIPTION
For use when you don't want to follow TEST naming convention.

Fix: #53