### PR TITLE
add functions rlCmpPkgVersion() and rlTestPkgVersion()

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -872,13 +872,12 @@ __INTERNAL_CreateHeader(){
     local line size
     # CPU info
     if [ -f "/proc/cpuinfo" ]; then
-        local count=0
-        local type="unknown"
         local cpu_regex="^model\sname.*: (.*)$"
+        local count=$(grep -cE "$cpu_regex" /proc/cpuinfo)
         while read -r line; do
             if [[ "$line" =~ $cpu_regex ]]; then
                 type="${BASH_REMATCH[1]}"
-                let count++
+                break
             fi
         done < "/proc/cpuinfo"
         __INTERNAL_WriteToMetafile hw_cpu -- "$count x $type"

--- a/src/journal.sh
+++ b/src/journal.sh
@@ -872,14 +872,10 @@ __INTERNAL_CreateHeader(){
     local line size
     # CPU info
     if [ -f "/proc/cpuinfo" ]; then
-        local cpu_regex="^model\sname.*: (.*)$"
-        local count=$(grep -cE "$cpu_regex" /proc/cpuinfo)
-        while read -r line; do
-            if [[ "$line" =~ $cpu_regex ]]; then
-                type="${BASH_REMATCH[1]}"
-                break
-            fi
-        done < "/proc/cpuinfo"
+        local cpu_regex count type
+        cpu_regex="^model\sname.*: (.*)$"
+        count=$(grep -cE "$cpu_regex" /proc/cpuinfo)
+        type="$(grep -E -m 1 "$cpu_regex" /proc/cpuinfo | sed -r "s/$cpu_regex/\1/")"
         __INTERNAL_WriteToMetafile hw_cpu -- "$count x $type"
         __INTERNAL_LogText "    CPUs          : $count x $type" 2> /dev/null
     fi

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -147,6 +147,20 @@ __INTERNAL_rlLibrarySearchInRoot(){
     return
   fi
 
+  local CANDIDATE="$BEAKERLIB_LIBRARY_PATH/$COMPONENT/$LIBRARY/lib.sh"
+  if [ -f "$CANDIDATE" ]
+  then
+    LIBFILE="$CANDIDATE"
+    return
+  fi
+
+  local CANDIDATE="$BEAKERLIB_LIBRARY_PATH/libs/$COMPONENT/$LIBRARY/lib.sh"
+  if [ -f "$CANDIDATE" ]
+  then
+    LIBFILE="$CANDIDATE"
+    return
+  fi
+
   rlLogDebug "rlImport: Library not found in $BEAKERLIB_LIBRARY_PATH"
 }
 

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -98,7 +98,7 @@ __INTERNAL_rlLibraryTraverseUpwards() {
   while [ "$DIRECTORY" != "/" ]
   do
     DIRECTORY="$( dirname $DIRECTORY )"
-    if [ -d "$DIRECTORY/$COMPONENT" ]
+    if [[ -d "$DIRECTORY/$COMPONENT" || -d "$DIRECTORY/libs/$COMPONENT/$LIBRARY" ]]
     then
 
       local CANDIDATE="$DIRECTORY/$COMPONENT/Library/$LIBRARY/lib.sh"
@@ -114,6 +114,14 @@ __INTERNAL_rlLibraryTraverseUpwards() {
         LIBFILE="$CANDIDATE"
         break
       fi
+
+      local CANDIDATE="$DIRECTORY/libs/$COMPONENT/$LIBRARY/lib.sh"
+      if [ -f "$CANDIDATE" ]
+      then
+        LIBFILE="$CANDIDATE"
+        break
+      fi
+
     fi
   done
 }

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -239,10 +239,25 @@ The library search mechanism is based on Beaker test hierarchy system, i.e.:
 
 /component/type/test-name/test-file
 
-When test-file calls rlImport with 'foo/bar' parameter, the directory path
-is traversed upwards, and a check for presence of the test /foo/Library/bar/
-will be performed. This means this function needs to be called from
-the test hierarchy, not e.g. the /tmp directory.
+When test-file calls rlImport with 'foo/bar' parameter, the lilraries are search
+in following locations:
+these are the possible path prefixes
+
+    - colon-separated paths from $BEAKERLIB_LIBRARY_PATH
+    - /mnt/tests
+    - /usr/share/beakerlib-libraries
+
+the next component of the path may be:
+
+    - /foo/Library/bar
+    - /*/foo/Library/bar
+    - /libs/foo/bar
+
+the directory path is then constructed as prefix/path/lib.sh
+If the library is still not found a upwards directory traversal is used, and a
+check for presence of the test /foo/Library/bar/ or libs/foo/bar/ is be
+performed. This means this function needs to be called from the test hierarchy,
+not e.g. the /tmp directory.
 
 Once library is found, it is sourced and a verifier function is called.
 The verifier function is cunstructed by composing the library prefix and

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -173,16 +173,20 @@ __INTERNAL_rlLibrarySearch() {
 
   if [ -n "$BEAKERLIB_LIBRARY_PATH" ]
   then
-    rlLogDebug "rlImport: BEAKERLIB_LIBRARY_PATH is set: trying to search in it"
-
-    __INTERNAL_rlLibrarySearchInRoot "$COMPONENT" "$LIBRARY" "$BEAKERLIB_LIBRARY_PATH"
-    if [ -n "$LIBFILE" ]
-    then
-      local VERSION="$(__INTERNAL_extractLibraryVersion "$LIBFILE" "$COMPONENT/$LIBRARY")"
-      VERSION=${VERSION:+", version '$VERSION'"}
-      rlLogInfo "rlImport: Found '$COMPONENT/$LIBRARY'$VERSION in BEAKERLIB_LIBRARY_PATH"
-      return
-    fi
+    rlLogDebug "rlImport: BEAKERLIB_LIBRARY_PATH='$BEAKERLIB_LIBRARY_PATH'"
+    local paths=( ${BEAKERLIB_LIBRARY_PATH//:/ } )
+    while [[ -n "$paths" ]]; do
+      rlLogDebug "$FUNCNAME(): trying $paths component of BEAKERLIB_LIBRARY_PATH"
+      __INTERNAL_rlLibrarySearchInRoot "$COMPONENT" "$LIBRARY" "$paths"
+      if [ -n "$LIBFILE" ]
+      then
+        local VERSION="$(__INTERNAL_extractLibraryVersion "$LIBFILE" "$COMPONENT/$LIBRARY")"
+        VERSION=${VERSION:+", version '$VERSION'"}
+        rlLogInfo "rlImport: Found '$COMPONENT/$LIBRARY'$VERSION in BEAKERLIB_LIBRARY_PATH"
+        return
+      fi
+      paths=( "${paths[@]:1}" )
+    done
   else
     rlLogDebug "rlImport: No BEAKERLIB_LIBRARY_PATH set: trying default"
   fi

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -239,7 +239,7 @@ The library search mechanism is based on Beaker test hierarchy system, i.e.:
 
 /component/type/test-name/test-file
 
-When test-file calls rlImport with 'foo/bar' parameter, the lilraries are search
+When test-file calls rlImport with 'foo/bar' parameter, the libraries are searched
 in following locations:
 these are the possible path prefixes
 
@@ -247,15 +247,15 @@ these are the possible path prefixes
     - /mnt/tests
     - /usr/share/beakerlib-libraries
 
-the next component of the path may be:
+the next component of the path is one of the following:
 
     - /foo/Library/bar
     - /*/foo/Library/bar
     - /libs/foo/bar
 
 the directory path is then constructed as prefix/path/lib.sh
-If the library is still not found a upwards directory traversal is used, and a
-check for presence of the test /foo/Library/bar/ or libs/foo/bar/ is be
+If the library is still not found an upwards directory traversal is used, and a
+check for presence of the library in /foo/Library/bar/ or libs/foo/bar/ is to be
 performed. This means this function needs to be called from the test hierarchy,
 not e.g. the /tmp directory.
 

--- a/src/test/testingTest.sh
+++ b/src/test/testingTest.sh
@@ -557,7 +557,7 @@ EOF
     assertTrue "test exit code" "[[ '$res' == '$exp_res' ]]"
     assertTrue "test printed character" "[[ '$op' == '$op2' ]]"
   done < $tmpfile
-  rm $tpmfile
+  rm $tmpfile
 
   # few asserts for --dist option
   assertLog "testing rlCmpPkgVersion --dist '\*' '$PKG_N' '$PKG_V'"

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -1304,8 +1304,17 @@ __INTERNAL_parse_EVR() {
 __INTERNAL_EVR_cmp() {
   local PKG1=( $( __INTERNAL_parse_EVR "$1" ) )
   local PKG2=( $( __INTERNAL_parse_EVR "$2" ) )
+  local PYTHON_BIN;
+  PYTHON_BIN=$( which python3 2>/dev/null ) || \
+  PYTHON_BIN=$( which python 2>/dev/null ) || \
+  PYTHON_BIN="/usr/bin/env python"
   # evaluate using python rpm.labelCompare
-  local RES=$( /usr/bin/env python -c "import rpm; print(rpm.labelCompare(('${PKG1[0]}', '${PKG1[1]}', '${PKG1[2]}'), ('${PKG2[0]}', '${PKG2[1]}', '${PKG2[2]}')))" )
+  local RES=$( $PYTHON_BIN -c "import rpm; \
+    print(rpm.labelCompare( \
+      ('${PKG1[0]}', '${PKG1[1]}', '${PKG1[2]}'), \
+      ('${PKG2[0]}', '${PKG2[1]}', '${PKG2[2]}') \
+    )) \
+  ")
   [ "$RES" == "0" ] && return 0
   [ "$RES" == "-1" ] && return 2
   [ "$RES" == "1" ] && return 1


### PR DESCRIPTION
Adds two new functions that are usable for testing the version of an installed RPM package.
Also it introduces new helper functions so that proper RPM Epoch:Version-Release arithmetics is used. 
Existing functions rlTestVersion() and rlCmpVersion are updated with the --rpm option that instructs them to follow RPM arithmetics.
Unfortunately, Python could not be avoided as the RPM arightmetics is not trivial.