### PR TITLE
fix function: rlAssertLesser for equal values

### DIFF
--- a/src/test/testingTest.sh
+++ b/src/test/testingTest.sh
@@ -230,6 +230,9 @@ test_rlAssertLesser(){
 	assertGoodBad 'rlAssertLesser "comment" -1 1' 1 0
 	assertGoodBad 'rlAssertLesser "comment" 1000 999' 0 1
 	assertGoodBad 'rlAssertLesser "comment" 100 10' 0 1
+	assertGoodBad 'rlAssertLesser "comment" 0 0' 0 1
+	assertGoodBad 'rlAssertLesser "comment" 8 8' 0 1
+	assertGoodBad 'rlAssertLesser "comment" -5 -5' 0 1
 	assertParameters 'rlAssertLesser comment -2 -1'
 }
 

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -356,12 +356,12 @@ Integer value.
 
 =back
 
-Returns 0 and asserts PASS when C<value1 E<le> value2>.
+Returns 0 and asserts PASS when C<value1 E<lt> value2>.
 
 =cut
 
 rlAssertLesser() {
-    __INTERNAL_ConditionalAssert "$1" "$([ "$2" -le "$3" ]; echo $?)" "(Assert: \"$2\" should be lesser than \"$3\")"
+    __INTERNAL_ConditionalAssert "$1" "$([ "$2" -lt "$3" ]; echo $?)" "(Assert: \"$2\" should be lesser than \"$3\")"
     return $?
 }
 


### PR DESCRIPTION
resolves #65 


Fix function rlAssertLesser for the same values.
Add 3 tests for this usecase.
Replace compare symbol in the documentation.