### PR TITLE
rlWaitForSocket fix - number of spaces

### DIFF
--- a/src/synchronisation.sh
+++ b/src/synchronisation.sh
@@ -482,9 +482,8 @@ rlWaitForSocket(){
             ;;
     esac
 
-    # sed replaces two or more whitespaces with a ';', to differentiate between
-    # spaces in values and spaces separating columns
-    local cmd="ss -Hnl | sed -e 's/\s\{2,\}/;/g' | awk -F ';' '{print \$$field}' | grep -E $grep_opt >/dev/null"
+    # $field-th column should contain either local address, or socket filename
+    local cmd="ss -Hnl | awk '{print \$$field}' | grep -E $grep_opt >/dev/null"
 
     if [[ ${close:-false} == true ]]; then
         rlLogInfo "rlWaitForSocket: Waiting max ${timeout}s for socket \`$socket' to close"


### PR DESCRIPTION
`ss` on Fedora 32 does not produce reliable number of spaces in its output. I changed `synchronisation.sh` not to do the magic of converting more than two spaces to semicolons. It works on RHEL-7, RHEL-8, Fedora-31, Fedora-32.

I am not 100% sure if it affects waiting for socket files. In my opinion it shouldn't, it will just not feed the socket number to the grep and it's grepping filename only anyway. But I'd appreciate if somebody who sees more into this can check.