### PR TITLE
make epel8 build pass

### DIFF
--- a/dist/beakerlib.spec
+++ b/dist/beakerlib.spec
@@ -53,20 +53,26 @@ BuildRequires: util-linux
 Source0:    https://github.com/beakerlib/beakerlib/archive/%{name}-%{version}.tar.gz
 Source1:    %{name}-tmpfiles.conf
 
-%if 0%{?fedora}
 Patch0: bugzilla-links.patch
-%else
-# rhel
 Patch1: bugzilla-links-epel.patch
-%endif
-%if 0%{?fedora}
 Patch2: python3.patch
-%elif 0%{?rhel} > 7
 Patch3: python.patch
-%endif
 
 %prep
-%autosetup -p1
+%autosetup -N -n beakerlib-1.21
+%if 0%{?fedora}
+%patch0 -p1
+%else
+# rhel
+%patch1 -p1
+%endif
+
+%if 0%{?fedora}
+%patch2 -p1
+%elif 0%{?rhel} > 7
+%patch3 -p1
+%endif
+
 
 %build
 make build

--- a/dist/beakerlib.spec
+++ b/dist/beakerlib.spec
@@ -69,7 +69,8 @@ Patch3: python.patch
 
 %if 0%{?fedora}
 %patch2 -p1
-%elif 0%{?rhel} > 7
+%endif
+%if 0%{?rhel} > 7
 %patch3 -p1
 %endif
 


### PR DESCRIPTION
```
    spec: define all patches, apply them conditionally instead

    this way all patches are defined all the time so the SRPM can be built
    on all supported platforms, the difference is that patches are applied
    conditionally based on the platform where the build is being done.
```

```
    spec: %elif -> %endif; %if

    there is no %elif on el8, sadly

    https://github.com/rpm-software-management/rpm/commit/1c4b238840d0995344d0d0381a0561b213429203
```

build passed for me locally:
```
$ mock --rebuild -r epel-8-x86_64 ./*.src.rpm
...
Wrote: /builddir/build/RPMS/beakerlib-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.el8.noarch.rpm
Wrote: /builddir/build/RPMS/beakerlib-vim-syntax-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.el8.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.gJA0j2
+ umask 022
+ cd /builddir/build/BUILD
+ cd beakerlib-1.21
+ /usr/bin/rm -rf /builddir/build/BUILDROOT/beakerlib-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.el8.x86_64
+ exit 0
Finish: rpmbuild beakerlib-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.fc33.src.rpm
Finish: build phase for beakerlib-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.fc33.src.rpm
INFO: Done(./beakerlib-1.21-1.20210105102651098916.pr.74.cond.patches.7.gc7a4af4.fc33.src.rpm) Config(epel-8-x86_64) 0 minutes 23 seconds
INFO: Results and/or logs in: /var/lib/mock/epel-8-x86_64/result
Finish: run
```