### PR TITLE
rlImport --all imports only 'required' libraries

### DIFF
--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -60,12 +60,12 @@ __INTERNAL_extractRequires(){
     declare -A yaml
     rlYash_parse yaml "$(cat $yaml_file)"
     local i
-    for i in `echo "${!yaml[@]}" | grep -E -o -e 'require\S*' -e 'recommend\S*'`; do
+    for i in `echo "${!yaml[@]}" | grep -E -o -e 'require\S*'`; do
       [[ "${yaml[$i]}" =~ library\(([^\)]+)\) ]] && __INTERNAL_LIBRARY_DEPS+=" ${BASH_REMATCH[1]}"
     done
     # parse libraries referenced by fmf id
     # [require.0.url]="https://github.com/RedHat-SP-Security/tests.git" [require.0.name]="/fapolicyd/Library/common
-    for i in `echo "${!yaml[@]}" | grep -E -o '(require|recommend)\.[0-9]+\.url' | grep -E -o '[^.]+\.[^.]+'`; do
+    for i in `echo "${!yaml[@]}" | grep -E -o '(require)\.[0-9]+\.url' | grep -E -o '[^.]+\.[^.]+'`; do
       [[ -n "${yaml[$i.name]}" && -n "${yaml[$i.url]}" ]] && {
         [[ "${yaml[$i.url]}" =~ .*/([^/]+)$ ]] && {
           __INTERNAL_LIBRARY_DEPS+=" ${BASH_REMATCH[1]%.git}/${yaml[$i.name]#/}"


### PR DESCRIPTION
Do not import _recommended_ libraries as it may produce unexpected failures.
The _recommended_ libraries will need to be imported explicitly.