### PR TITLE
rlRun_LOG defined and deleted as an array

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -266,12 +266,12 @@ rlJournalEnd(){
         [[ "$BEAKERLIB_JOURNAL" == "0" ]] || rlLog "JOURNAL XML: $__INTERNAL_BEAKERLIB_JOURNAL"
         rlLog "JOURNAL TXT: $__INTERNAL_BEAKERLIB_JOURNAL_TXT"
     fi
-    if (( ${#rlRun_LOG[@]} ))
-    then
-    rm -f "${rlRun_LOG[@]}"
-    rlLogInfo "Deleting rlRun_LOG file(s)"
-    local tmp_LOG=${rlRun_LOG[*]}
-    rlLogDebug "Deleting temporary file(s) ${tmp_LOG// /, }"
+
+    if (( ${#rlRun_LOG[@]} )); then
+        rm -f "${rlRun_LOG[@]}"
+        rlLogInfo "Deleting rlRun_LOG file(s)"
+        local tmp_LOG=${rlRun_LOG[*]}
+        rlLogDebug "Deleting temporary file(s) ${tmp_LOG// /, }"
     fi
 
     echo "#End of metafile" >> "$__INTERNAL_BEAKERLIB_METAFILE"

--- a/src/journal.sh
+++ b/src/journal.sh
@@ -266,6 +266,14 @@ rlJournalEnd(){
         [[ "$BEAKERLIB_JOURNAL" == "0" ]] || rlLog "JOURNAL XML: $__INTERNAL_BEAKERLIB_JOURNAL"
         rlLog "JOURNAL TXT: $__INTERNAL_BEAKERLIB_JOURNAL_TXT"
     fi
+    if (( ${#rlRun_LOG[@]} ))
+    then
+    for i in "${rlRun_LOG[@]}"
+    do
+    rm -f "$i"
+    rlLogInfo "Deleting file $i"
+    done
+    fi
 
     echo "#End of metafile" >> "$__INTERNAL_BEAKERLIB_METAFILE"
 

--- a/src/journal.sh
+++ b/src/journal.sh
@@ -268,11 +268,10 @@ rlJournalEnd(){
     fi
     if (( ${#rlRun_LOG[@]} ))
     then
-    for i in "${rlRun_LOG[@]}"
-    do
-    rm -f "$i"
-    rlLogInfo "Deleting file $i"
-    done
+    rm -f "${rlRun_LOG[@]}"
+    rlLogInfo "Deleting rlRun_LOG file(s)"
+    local tmp_LOG=${rlRun_LOG[*]}
+    rlLogDebug "Deleting temporary file(s) ${tmp_LOG// /, }"
     fi
 
     echo "#End of metafile" >> "$__INTERNAL_BEAKERLIB_METAFILE"

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -910,7 +910,7 @@ rlRun() {
         rlLog "---------------  OUTPUT END  ---------------"
     fi
     if $__INTERNAL_rlRun_DO_KEEP; then
-        rlRun_LOG=$__INTERNAL_rlRun_LOG_FILE
+        rlRun_LOG=( "$__INTERNAL_rlRun_LOG_FILE" "${rlRun_LOG[@]}" )
         export rlRun_LOG
     elif $__INTERNAL_rlRun_DO_LOG; then
         rm $__INTERNAL_rlRun_LOG_FILE

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -689,9 +689,10 @@ Same as C<-l>, but only log the command output if it failed.
 =item -s
 
 Store stdout and stderr to a file (mixed together, as the user would see
-it on a terminal) and set $rlRun_LOG variable to name of the file. Caller
-is responsible for removing the file. When -t option is used, the content
-of the file becomes tagged too.
+it on a terminal) and set $rlRun_LOG variable to name of the file. $rlRun_LOG
+works as an array formed by the prepend method and it is removed afterwards
+in the rlJournalEnd section, so it does not require any additional manual removal.
+When -t option is used, the content of the file becomes tagged too.
 
 If the -s option is not used, $rlRun_LOG is not modified and keeps its
 content from the last "rlRun -s".

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -690,8 +690,12 @@ Same as C<-l>, but only log the command output if it failed.
 
 Store stdout and stderr to a file (mixed together, as the user would see
 it on a terminal) and set $rlRun_LOG variable to name of the file. $rlRun_LOG
-works as an array formed by the prepend method and it is removed afterwards
-in the rlJournalEnd section, so it does not require any additional manual removal.
+is now actually an array where the first index holds the last reference to the file.
+Thus its behavior is not changed if used without an index. The array is consumed by
+the rlJournalEnd function to remove the leftover files, so no manual files removal
+is needed anymore.
+Note that if you need to use such a file after calling the rlJournalEnd function
+you need to create your own copy of the respective file.
 When -t option is used, the content of the file becomes tagged too.
 
 If the -s option is not used, $rlRun_LOG is not modified and keeps its


### PR DESCRIPTION
temporary files are grouped in an array rlRun_LOG (by the prepend method) that is afterwards deleted at once in rlJournalEnd (so it does not require manual removal)