### PR TITLE
Dependencies check

### DIFF
--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -428,6 +428,7 @@ Return 0 if success.
 rlGetYAMLdeps() {
   local file yaml __deps_var_name __deps type
   __deps_var_name=${2:-__deps}
+  eval "$__deps_var_name=()"
   type="${1:-require}"
   file="$BEAKERLIB_DIR/metadata.yaml"
   [[ -s "$file" ]] || {

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -656,8 +656,13 @@ rlCheckRecommended() {
 # rlCheckDependencies
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 rlCheckDependencies() {
+  local res=0
   rlCheckRecommended
+  let res+=$?
   rlCheckRequired
+  let res+=$?
+  [[ $res -gt 255 ]] && res=255
+  return $res
 }
 
 

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -616,6 +616,70 @@ rlCheckMakefileRequires() {
 : <<'=cut'
 =pod
 
+=head3 rlGetRequired
+=head3 rlGetRecommended
+
+Get a list of required or recommended packages / binaries defined in
+B<metadata.yaml> provided by C<tmt> or in a Makefile of the test.
+
+    rlGetRequired [ARRAY_VAR_NAME]
+    rlGetRecommended [ARRAY_VAR_NAME]
+
+=over
+
+=item I<ARRAY_VAR_NAME>
+
+If provided the variable is populated as an array with the respective
+dependencies. Otherwise the dependencies are printed out to the I<STDOUT>.
+
+=back
+
+Return 255 if requirements could not be retrieved, 0 otherwise.
+
+=cut
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlGetRequired
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+rlGetRequired() {
+  local __res=0 IFS __deps_var_name ___deps
+  __deps_var_name=${1:-___deps}
+  eval "$__deps_var_name=()"
+  rlGetYAMLdeps 'require' $__deps_var_name || let __res++
+  eval "$__deps_var_name+=( \$(rlGetMakefileRequires) ) || let __res++"
+  if [[ $__res -lt 2 ]]; then
+    if [[ -z "$1" ]]; then
+      eval "echo \"\${$__deps_var_name[*]}\""
+    fi
+    return 0
+  else
+    return 255
+  fi
+}
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlGetRecommended
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+rlGetRecommended() {
+  local __res=0 IFS __deps_var_name ___deps
+  __deps_var_name=${1:-___deps}
+  eval "$__deps_var_name=()"
+  rlGetYAMLdeps 'recommend' $__deps_var_name || let __res++
+  if [[ $__res -lt 1 ]]; then
+    if [[ -z "$1" ]]; then
+      eval "echo \"\${$__deps_var_name[*]}\""
+    fi
+    return 0
+  else
+    return 255
+  fi
+}
+
+
+: <<'=cut'
+=pod
+
 =head3 rlCheckRequired
 =head3 rlCheckRecommended
 =head3 rlCheckDependencies

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -606,11 +606,11 @@ rlCheckMakefileRequires() {
     rlCheckRequirements "${req[@]}"
   fi
   rlGetRequired req
-  let res=$?
+  res=$?
   if [[ -n "$req" ]]; then
     rlLogInfo "required:"
     rlCheckRequirements "${req[@]}"
-    let res=$?
+    res=$?
   fi
   return $res
 }; # end of rlCheckMakefileRequires

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -595,6 +595,8 @@ satisfied or number of unsatisfied requirements.
 
 rlCheckMakefileRequires() {
   local req IFS
+  rlLogWarning "$FUNCNAME: considering FMF dependencies through metadata.yaml will be removed in near future"
+  rlLogWarning "$FUNCNAME:   use rlCheckDependencies or tandem rlCheckRequired / rlCheckRecommend instead"
   rlGetYAMLdeps 'recommend' req && {
     [[ ${#req[@]} -gt 0 ]] && rlCheckRequirements "${req[@]}"
   }
@@ -602,6 +604,54 @@ rlCheckMakefileRequires() {
   req=( $(rlGetMakefileRequires) ) || return 255
   rlCheckRequirements "${req[@]}"
 }; # end of rlCheckMakefileRequires
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlCheckRequired
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+rlCheckRequired() {
+  local req=() res=0 IFS
+  rlGetYAMLdeps 'require' req || let res++
+  req+=( $(rlGetMakefileRequires) ) || let res++
+  if [[ -n "$req" ]]; then
+    rlCheckRequirements "${req[@]}"
+    return $?
+  else
+    if [[ $res -lt 2 ]]; then
+      return 0
+    else
+      return 255
+    fi
+  fi
+}
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlCheckRecommended
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+rlCheckRecommended() {
+  local req=() res=0
+  rlGetYAMLdeps 'recommend' req || let res++
+  if [[ -n "$req" ]]; then
+    rlCheckRequirements "${req[@]}"
+    return $?
+  else
+    if [[ $res -lt 1 ]]; then
+      return 0
+    else
+      return 255
+    fi
+  fi
+}
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# rlCheckDependencies
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+rlCheckDependencies() {
+  rlCheckRecommended
+  rlCheckRequired
+}
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -601,10 +601,14 @@ rlCheckMakefileRequires() {
   rlLogWarning "$FUNCNAME: considering FMF dependencies through metadata.yaml will be removed in near future"
   rlLogWarning "$FUNCNAME:   use rlCheckDependencies or tandem rlCheckRequired / rlCheckRecommended instead"
   rlGetYAMLdeps 'recommend' req && {
-    [[ ${#req[@]} -gt 0 ]] && rlCheckRequirements "${req[@]}"
+    [[ ${#req[@]} -gt 0 ]] && {
+      rlLogInfo "recommended:"
+      rlCheckRequirements "${req[@]}"
+    }
   }
   rlGetYAMLdeps 'require' req || \
   req=( $(rlGetMakefileRequires) ) || return 255
+  rlLogInfo "required:"
   rlCheckRequirements "${req[@]}"
 }; # end of rlCheckMakefileRequires
 

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -613,6 +613,29 @@ rlCheckMakefileRequires() {
 }; # end of rlCheckMakefileRequires
 
 
+: <<'=cut'
+=pod
+
+=head3 rlCheckRequired
+=head3 rlCheckRecommended
+=head3 rlCheckDependencies
+
+Check presence of required, recommended or both packages / binaries defined in
+B<metadata.yaml> provided by C<tmt> or in a Makefile of the test.
+
+=head3 Example
+
+    rlRun "rlCheckRequired"
+    rlRun "rlCheckRecommended"
+    rlRun "rlCheckDependencies"
+
+Return 255 if requirements could not be retrieved, 0 if all requirements are
+satisfied or number of unsatisfied requirements.
+
+
+
+=cut
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # rlCheckRequired
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -578,9 +578,12 @@ rlCheckRequirements() {
 
 =head3 rlCheckMakefileRequires
 
-This is just a bit smarted wrapper of
+Check presence of required packages / binaries defined in B<metadata.yaml> provided
+by C<tmt> or Makefile of the test.
 
-C<rlCheckRequirements $(rlGetYAMLdeps 'require|recommend') || rlCheckRequirements $(rlGetMakefileRequires)>
+Also check presence of recommended packages / binaries defined in B<metadata.yaml>
+provided by C<tmt>. These however do not participate on the return code, these
+are just informative.
 
 =head3 Example
 
@@ -596,7 +599,7 @@ satisfied or number of unsatisfied requirements.
 rlCheckMakefileRequires() {
   local req IFS
   rlLogWarning "$FUNCNAME: considering FMF dependencies through metadata.yaml will be removed in near future"
-  rlLogWarning "$FUNCNAME:   use rlCheckDependencies or tandem rlCheckRequired / rlCheckRecommend instead"
+  rlLogWarning "$FUNCNAME:   use rlCheckDependencies or tandem rlCheckRequired / rlCheckRecommended instead"
   rlGetYAMLdeps 'recommend' req && {
     [[ ${#req[@]} -gt 0 ]] && rlCheckRequirements "${req[@]}"
   }

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -662,9 +662,8 @@ rlCheckDependencies() {
 
 =head3 rlAssertRequired
 
-Ensures that all requires and recommends specified in the metadata.yaml are installed.
-If no metadata.yaml is present a fallback to Makefile is done to check Requires
-specified in beakerlib-style beaker-wizard layout Makefile, are installed.
+Ensures that all required packages provided in either metadata.yaml or Makefile
+are installed.
 
     rlAssertRequired
 
@@ -676,33 +675,13 @@ or more packages are missing or if no Makefile is present.
 =cut
 
 rlAssertRequired(){
-    local MAKEFILE="Makefile"
-    local list
+    local res
+    rlCheckRequired
+    res=$?
 
-    if list="$(rlGetYAMLdeps 'require|recommend')"; then
-        if [ -z "$list" ]; then
-            rlLogError "rlAssertRequired: did not find any requires/recommends in the metadata.yaml"
-            return 1
-        fi
-    elif [ -e "$MAKEFILE" ]; then
-        rlLogInfo "rlAssertRequired: $MAKEFILE found, goint to use it"
-        list="$(grep 'Requires:' $MAKEFILE)"
-        if [ -z "$list" ]; then
-            rlLogError "rlAssertRequired: $MAKEFILE does not contain 'Requires:'"
-            return 1
-        fi
-        list=$(echo "$list" | sed -r 's/^[ \t]+@echo "Requires:[ \t]+([^"]+)" >> \$\(METADATA\)$/\1/' | tr '\n' ' ')
-    else
-        rlLogError "rlAssertRequired: could not find any suitable source of the requirements"
-        return 1
-    fi
+    __INTERNAL_ConditionalAssert "Assert required packages installed" $res
 
-
-    rpm -q $list
-
-    __INTERNAL_ConditionalAssert "Assert required packages installed" $?
-
-    return $?
+    return $res
 }
 
 

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -594,8 +594,11 @@ satisfied or number of unsatisfied requirements.
 =cut
 
 rlCheckMakefileRequires() {
-  local req
-  rlGetYAMLdeps 'require|recommend' req || \
+  local req IFS
+  rlGetYAMLdeps 'recommend' req && {
+    [[ ${#req[@]} -gt 0 ]] && rlCheckRequirements "${req[@]}"
+  }
+  rlGetYAMLdeps 'require' req || \
   req=( $(rlGetMakefileRequires) ) || return 255
   rlCheckRequirements "${req[@]}"
 }; # end of rlCheckMakefileRequires


### PR DESCRIPTION
* reworked functions for dependency checking and asserting
* also added new functions covering check of required, recommended and both
  * `rlCheckRerquired`
  * `rlCheckRecommended`
  * `rlCheckDependencies`
* now, all the functions should use `rlCheckRequirements` which is also able to handle requirement in the form `bash >= 4.1`

This update and consequent package build availability should enable https://github.com/psss/tmt/pull/667 to be merged.