### PR TITLE
packit: build for arm64

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,26 +17,38 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all
-    - centos-stream-8
-    - centos-stream-9
-    - epel-6
-    - epel-all
+    - fedora-all-x86_64
+    - fedora-all-aarch64
+    - centos-stream-8-x86_64
+    - centos-stream-8-aarch64
+    - centos-stream-9-x86_64
+    - centos-stream-9-aarch64
+    - epel-6-x86_64
+    - epel-6-aarch64
+    - epel-all-x86_64
+    - epel-all-aarch64
 
 - job: copr_build
   trigger: commit
   metadata:
     branch: master
     targets:
-    - fedora-all
-    - centos-stream-8
-    - centos-stream-9
-    - epel-6
-    - epel-all
+    - fedora-all-x86_64
+    - fedora-all-aarch64
+    - centos-stream-8-x86_64
+    - centos-stream-8-aarch64
+    - centos-stream-9-x86_64
+    - centos-stream-9-aarch64
+    - epel-6-x86_64
+    - epel-6-aarch64
+    - epel-all-x86_64
+    - epel-all-aarch64
 
 - job: tests
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all
-    - epel-8
+    - fedora-all-x86_64
+    - fedora-all-aarch64
+    - epel-8-x86_64
+    - epel-8-aarch64

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,16 +17,11 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all-x86_64
-    - fedora-all-aarch64
-    - centos-stream-8-x86_64
-    - centos-stream-8-aarch64
-    - centos-stream-9-x86_64
-    - centos-stream-9-aarch64
-    - epel-6-x86_64
-    - epel-6-aarch64
-    - epel-all-x86_64
-    - epel-all-aarch64
+    - fedora-all
+    - centos-stream-8
+    - centos-stream-9
+    - epel-6
+    - epel-all
 
 - job: copr_build
   trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -48,7 +48,5 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all-x86_64
-    - fedora-all-aarch64
-    - epel-8-x86_64
-    - epel-8-aarch64
+    - fedora-all
+    - epel-8


### PR DESCRIPTION
We are getting more use cases where arm64 architecture
is used, let's make sure latest beakerlib is around as
a copr repository for it.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>