### PR TITLE
Consider local libraries when run through tmt for rlImport

### DIFF
--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -140,7 +140,8 @@ __INTERNAL_rlLibrarySearchInDir(){
     "$DIRECTORY/libs/$COMPONENT$LIBRARY/lib.sh" \
     $DIRECTORY/*/$COMPONENT/Library$LIBRARY/lib.sh \
     $DIRECTORY/libs/*/$COMPONENT/Library$LIBRARY/lib.sh \
-    $DIRECTORY/libs/*/$COMPONENT$LIBRARY/lib.sh
+    $DIRECTORY/libs/*/$COMPONENT$LIBRARY/lib.sh \
+    "$DIRECTORY/tree/Library/$LIBRARY/lib.sh"
   do
     rlLogDebug "$FUNCNAME(): trying '$CANDIDATE'"
     if [[ -f "$CANDIDATE" ]]; then


### PR DESCRIPTION
At least partially fixing https://github.com/psss/tmt/issues/522.
Also enabling more RHEL/RHIVOS tests to be run through tmt without any other changes.