### PR TITLE
libraries.sh: added a support to import a library located in the current directory

### DIFF
--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -168,6 +168,12 @@ __INTERNAL_rlLibrarySearch() {
 
   local LIBRARY="$1"
 
+  if [[ "$LIBRARY" == "." ]]; then
+    rlLogInfo "rlImport: Looking for a library in the test's directory"
+    [[ -e ${__INTERNAL_TraverseRoot}/lib.sh ]] && LIBFILE="${__INTERNAL_TraverseRoot}/lib.sh"
+    return
+  fi
+
   rlLogDebug "rlImport: Looking if we got BEAKERLIB_LIBRARY_PATH"
 
   if [ -n "$BEAKERLIB_LIBRARY_PATH" ]
@@ -282,7 +288,8 @@ and import them all.
 
 =item LIBRARY
 
-Must have 'component[/path]' format. Identifies the library to import.
+Must have 'component[/path]' or '.' format. Identifies the library to import.
+The dot (.) is a special case where the lib.sh from the current directory is used.
 
 =back
 


### PR DESCRIPTION
This is useful mainly for development purposes.
It may be useful also for the library's test suite as well.