### PR TITLE
rlRun -l: log also the last line

### DIFF
--- a/src/testing.sh
+++ b/src/testing.sh
@@ -908,7 +908,7 @@ rlRun() {
         rlLog "Output of '$__INTERNAL_rlRun_command':"
         rlLog "--------------- OUTPUT START ---------------"
         local __INTERNAL_rlRun_line
-        tail -n 50 "$__INTERNAL_rlRun_LOG_FILE" | while read __INTERNAL_rlRun_line
+        tail -n 50 "$__INTERNAL_rlRun_LOG_FILE" | while read -r __INTERNAL_rlRun_line || [[ -n "$__INTERNAL_rlRun_line" ]]
         do
           rlLog "$__INTERNAL_rlRun_line"
         done


### PR DESCRIPTION
If there's no newline character at the end of the last line
it was not logged at all.
This patch fixes the issue.