### PR TITLE
libraries: consider also 'nick' attribute of fmf_id

### DIFF
--- a/dist/beakerlib.spec
+++ b/dist/beakerlib.spec
@@ -1,6 +1,6 @@
 Name:       beakerlib
 Summary:    A shell-level integration testing library
-Version:    1.29.2
+Version:    1.29.3
 Release:    1%{?dist}
 License:    GPLv2
 BuildArch:  noarch
@@ -129,6 +129,9 @@ Files for syntax highlighting BeakerLib tests in VIM editor
 %{_datadir}/vim/vimfiles/after/syntax/beakerlib.vim
 
 %changelog
+* Thu Oct 20 2022 Dalibor Pospisil <dapospis@redhat.com> - 1.29.3-1
+- support for fmf_id nick attribute
+
 * Thu Aug 25 2022 Dalibor Pospisil <dapospis@redhat.com> - 1.29.2-1
 - improved performance and memory consumption of the fingerprint feature
 

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -73,7 +73,9 @@ __INTERNAL_extractRequires(){
         if [[ -n "${yaml[$i.url]}" ]]; then
           [[ "${yaml[$i.url]}" =~ .*/([^/]+)$ ]] && {
             # try to process library in COMPONENT/LIBNAME format
-            __INTERNAL_LIBRARY_DEPS+=" ${BASH_REMATCH[1]%.git}/${lib_path}${yaml[$i.name]#/}"
+            local component="${BASH_REMATCH[1]%.git}"
+            [[ -n "${yaml[$i.nick]}" ]] && component="${yaml[$i.nick]}"
+            __INTERNAL_LIBRARY_DEPS+=" ${component}/${lib_path}${yaml[$i.name]#/}"
           }
         else
           # try to process library in the LIBNAME format (withing the current repository)


### PR DESCRIPTION
Previously, the nick attirbute was completely ignored, that lead to rlImport to search in wrong paths for the library.

Now, the nick is used as a component name instead of a part of the url while searching for the library.