### PR TITLE
src: use `grep -E` instead of `egrep`

### DIFF
--- a/src/logging.sh
+++ b/src/logging.sh
@@ -540,7 +540,7 @@ rlFileSubmit() {
         if [ -n "$2" ]; then
             ALIAS="$2"
         else
-            if echo "$FILE" | egrep -q "^\.(\.)?/"; then
+            if echo "$FILE" | grep -E -q "^\.(\.)?/"; then
                 # ^ if the path is specified as relative ~ begins with ./ or ../
                 local POM=$(dirname "$FILE")
                 ALIAS=$(cd "$POM"; pwd)

--- a/src/test/test.sh
+++ b/src/test/test.sh
@@ -187,14 +187,14 @@ assertGoodBad() {
         rm -f $__INTERNAL_BEAKERLIB_JOURNAL $__INTERNAL_BEAKERLIB_METAFILE $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_TXT $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_COLORED $__INTERNAL_PRESISTENT_DATA; rlJournalStart
         assertTrue "$good good logged for '$command'" \
                 "rlPhaseStart FAIL; $command; rlPhaseEnd;
-                rlJournalPrintText | egrep 'Assertions: *$good *good, *[0-9]+ *bad'"
+                rlJournalPrintText | grep -E 'Assertions: *$good *good, *[0-9]+ *bad'"
     fi
 
     if [[ -n "$bad" ]]; then
         rm -f $__INTERNAL_BEAKERLIB_JOURNAL $__INTERNAL_BEAKERLIB_METAFILE $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_TXT $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_COLORED $__INTERNAL_PRESISTENT_DATA; rlJournalStart
         assertTrue "$bad bad logged for '$command'" \
                 "rlPhaseStart FAIL; $command; rlPhaseEnd;
-                rlJournalPrintText | egrep 'Assertions: *[0-9]+ *good, *$bad *bad'"
+                rlJournalPrintText | grep -E 'Assertions: *[0-9]+ *good, *$bad *bad'"
     fi
     rm -f $__INTERNAL_BEAKERLIB_JOURNAL $__INTERNAL_BEAKERLIB_METAFILE $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_TXT $__INTERNAL___INTERNAL_BEAKERLIB_JOURNAL_COLORED $__INTERNAL_PRESISTENT_DATA
 }

--- a/src/test/testingTest.sh
+++ b/src/test/testingTest.sh
@@ -281,7 +281,7 @@ test_rlRun(){
     PREFIX_REGEXP='^:: \[ [0-9]{2}:[0-9]{2}:[0-9]{2} \] :: \[   LOG    \] ::[[:space:]]+'
 
     silentIfNotDebug "rlRun -l 'echo \"foobar3\"'"
-    grep 'echo "foobar3"' "$OUTPUTFILE" --quiet && egrep "${PREFIX_REGEXP}"'foobar3' "$OUTPUTFILE" --quiet
+    grep 'echo "foobar3"' "$OUTPUTFILE" --quiet && grep -E "${PREFIX_REGEXP}"'foobar3' "$OUTPUTFILE" --quiet
     assertTrue "rlRun logging plain" "[ $? -eq 0 ]"
 
     rm -f foobar3
@@ -292,11 +292,11 @@ test_rlRun(){
     assertTrue "rlRun logging plain with bad exit code" "[ $? -eq 1 ]"
 
     silentIfNotDebug "rlRun -l -t 'echo \"foobar4\"'"
-    grep 'echo "foobar4"' "$OUTPUTFILE" --quiet && egrep "${PREFIX_REGEXP}"'STDOUT: foobar4' "$OUTPUTFILE" --quiet
+    grep 'echo "foobar4"' "$OUTPUTFILE" --quiet && grep -E "${PREFIX_REGEXP}"'STDOUT: foobar4' "$OUTPUTFILE" --quiet
     assertTrue "rlRun logging with tagging (stdout)" "[ $? -eq 0 ]"
 
     silentIfNotDebug "rlRun -l -t 'echo \"foobar5\" 1>&2'"
-    grep 'echo "foobar5" 1>&2' "$OUTPUTFILE" --quiet && egrep "${PREFIX_REGEXP}"'STDERR: foobar5' "$OUTPUTFILE" --quiet
+    grep 'echo "foobar5" 1>&2' "$OUTPUTFILE" --quiet && grep -E "${PREFIX_REGEXP}"'STDERR: foobar5' "$OUTPUTFILE" --quiet
     assertTrue "rlRun logging with tagging (stderr)" "[ $? -eq 0 ]"
 
     silentIfNotDebug "rlRun -s 'echo \"foobar6_stdout\"; echo \"foobar6_stderr\" 1>&2'"
@@ -307,7 +307,7 @@ test_rlRun(){
 
     rm -f foobar7
     silentIfNotDebug "rlRun -c 'cat \"foobar7\"'"
-    grep 'cat "foobar7"' "$OUTPUTFILE" --quiet && egrep "${PREFIX_REGEXP}"'cat: foobar7: No such file or directory' "$OUTPUTFILE" --quiet
+    grep 'cat "foobar7"' "$OUTPUTFILE" --quiet && grep -E "${PREFIX_REGEXP}"'cat: foobar7: No such file or directory' "$OUTPUTFILE" --quiet
     assertTrue "rlRun conditional logging plain" "[ $? -eq 0 ]"
 
     echo 'foobar8_content' > foobar8
@@ -320,7 +320,7 @@ test_rlRun(){
 
     rm -f foobar9
     silentIfNotDebug "rlRun -c -t 'cat \"foobar9\" 1>&2'"
-    grep 'cat "foobar9" 1>&2' "$OUTPUTFILE" --quiet && egrep "${PREFIX_REGEXP}"'STDERR: cat: foobar9: No such file or directory' "$OUTPUTFILE" --quiet
+    grep 'cat "foobar9" 1>&2' "$OUTPUTFILE" --quiet && grep -E "${PREFIX_REGEXP}"'STDERR: cat: foobar9: No such file or directory' "$OUTPUTFILE" --quiet
     assertTrue "rlRun conditional logging with tagging (stderr)" "[ $? -eq 0 ]"
 
     assertGoodBad 'rlRun "false|true"' 1 0


### PR DESCRIPTION
`egrep` was deprecated in GNU grep 3.8. This change was done using
```sh
$ find src -name '*.sh' -exec sed -i 's/egrep/grep -E/g' {} \;
```

Fixes:
```
egrep: warning: egrep is obsolescent; using grep -E
```

Can be seen e.g. at the beginning of the following test log on Fedora Rawhide:
https://artifacts.dev.testing-farm.io/d85b93c1-fffe-44f4-8d53-99896290648f/work-tests.ymle821oxz5/tests-ojftz554/PASS-file-tests-err.log