### PR TITLE
enable downstream release handling via packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,8 +42,7 @@ jobs:
 - job: propose_downstream
   trigger: release
   dist_git_branches:
-    - fedora-rawhide
-    - fedora-branched
+    - fedora-all
     - epel-all
 
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,52 +9,52 @@ upstream_package_name: beakerlib
 downstream_package_name: beakerlib
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  targets:
-  - fedora-all
-  - centos-stream-8
-  - centos-stream-9
-  - epel-6
-  - epel-all
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-all
+      - centos-stream-8
+      - centos-stream-9
+      - epel-6
+      - epel-all
 
-- job: copr_build
-  trigger: commit
-  branch: master
-  targets:
-  - fedora-all-x86_64
-  - fedora-all-aarch64
-  - centos-stream-8-x86_64
-  - centos-stream-8-aarch64
-  - centos-stream-9-x86_64
-  - centos-stream-9-aarch64
-  - epel-6-x86_64
-  - epel-6-aarch64
-  - epel-all-x86_64
-  - epel-all-aarch64
+  - job: copr_build
+    trigger: commit
+    branch: master
+    targets:
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+      - centos-stream-8-x86_64
+      - centos-stream-8-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - epel-6-x86_64
+      - epel-6-aarch64
+      - epel-all-x86_64
+      - epel-all-aarch64
 
-- job: tests
-  trigger: pull_request
-  targets:
-  - fedora-all
-  - epel-8
+  - job: tests
+    trigger: pull_request
+    targets:
+      - fedora-all
+      - epel-8
 
-- job: propose_downstream
-  trigger: release
-  dist_git_branches:
-    - fedora-all
-    - epel-all
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all
+      - epel-all
 
-- job: koji_build
-  trigger: commit
-  allowed_pr_authors: ["packit", "sopos"]
-  dist_git_branches:
-    - fedora-all
-    - epel-all
+  - job: koji_build
+    trigger: commit
+    allowed_pr_authors: ["packit", "sopos"]
+    dist_git_branches:
+      - fedora-all
+      - epel-all
 
 jobs:
-- job: bodhi_update
-  trigger: commit
-  dist_git_branches:
-    - fedora-branched
-    - epel-all
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched
+      - epel-all

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,43 +5,33 @@ specfile_path: dist/beakerlib.spec
 upstream_package_name: beakerlib
 downstream_package_name: beakerlib
 
-
-#actions:
-#  create-archive:
-#  - make tarball
-#  get-current-version:
-#  - make version
-
 jobs:
 - job: copr_build
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - centos-stream-8
-    - centos-stream-9
-    - epel-6
-    - epel-all
+  targets:
+  - fedora-all
+  - centos-stream-8
+  - centos-stream-9
+  - epel-6
+  - epel-all
 
 - job: copr_build
   trigger: commit
-  metadata:
-    branch: master
-    targets:
-    - fedora-all-x86_64
-    - fedora-all-aarch64
-    - centos-stream-8-x86_64
-    - centos-stream-8-aarch64
-    - centos-stream-9-x86_64
-    - centos-stream-9-aarch64
-    - epel-6-x86_64
-    - epel-6-aarch64
-    - epel-all-x86_64
-    - epel-all-aarch64
+  branch: master
+  targets:
+  - fedora-all-x86_64
+  - fedora-all-aarch64
+  - centos-stream-8-x86_64
+  - centos-stream-8-aarch64
+  - centos-stream-9-x86_64
+  - centos-stream-9-aarch64
+  - epel-6-x86_64
+  - epel-6-aarch64
+  - epel-all-x86_64
+  - epel-all-aarch64
 
 - job: tests
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - epel-8
+  targets:
+  - fedora-all
+  - epel-8

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,7 +37,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
-      - epel-8
+      - epel-9
 
   - job: propose_downstream
     trigger: release

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -48,7 +48,7 @@ jobs:
 
 - job: koji_build
   trigger: commit
-  allowed_committers: ["sopos"]
+  allowed_pr_authors: ["packit", "sopos"]
   dist_git_branches:
     - fedora-all
     - epel-all

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,9 @@
 specfile_path: dist/beakerlib.spec
-#synced_files:
-#    - beakerlib.spec
+
+files_to_sync:
+  - src: dist/*
+    dest: .
+  - .packit.yaml
 
 upstream_package_name: beakerlib
 downstream_package_name: beakerlib
@@ -35,3 +38,24 @@ jobs:
   targets:
   - fedora-all
   - epel-8
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-rawhide
+    - fedora-branched
+    - epel-all
+
+- job: koji_build
+  trigger: commit
+  allowed_committers: ["sopos"]
+  dist_git_branches:
+    - fedora-all
+    - epel-all
+
+jobs:
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-branched
+    - epel-all


### PR DESCRIPTION
enables automated Fedora releases
- create downstream PRs for the release
- automatically create downstream Koji builds base on the merged PRs
- automatically created Bodhi updates for the builds