### PR TITLE
fix: tmt integration

### DIFF
--- a/plans/tmt.fmf
+++ b/plans/tmt.fmf
@@ -1,13 +1,6 @@
-summary:
-    Run integration tests with tmt
-discover:
-    how: fmf
-    url: https://github.com/psss/tmt
-    ref: fedora
-    test: execute
-    filter: 'tier: 1, 2'
-prepare:
-    how: install
-    package: tmt-all
-execute:
-    how: tmt
+summary: Run tmt's integration tests
+plan:
+    import:
+        url: https://github.com/teemtee/tmt
+        path: /plans/friends
+        name: /beakerlib


### PR DESCRIPTION
- update tmt url reference
- bump test target to epel-9
- cleanup packit.yaml file
- fix test filtering
- fix tmt plan packages

Depends on https://github.com/teemtee/tmt/pull/2731