### PR TITLE
Alias gnu commands for homebrew packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ ifndef PKGDOCDIR
 	export PKGDOCDIR := $(DESTDIR)/share/doc/$(PKGNAME)/
 endif
 
+# Command aliases for homebrew and non-gnu compatibilities
+ifndef GETOPT_CMD
+	export GETOPT_CMD := getopt
+endif
+ifndef READLINK_CMD
+	export READLINK_CMD := readlink
+endif
+
 SUBDIRS := src
 
 build:

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,13 @@ MODULES=journal.sh\
 FILES=$(MODULES) beakerlib.sh
 DEFDOCS=dictionary.vim docsman
 
+define portable_sed
+	# See comment inside https://unix.stackexchange.com/a/92907
+	sed -e $(1) $(2) > $(2).tmp
+	cat $(2).tmp > $(2)
+	rm -f $(2).tmp
+endef
+
 .PHONY: install clean test
 
 ya.sh:
@@ -64,6 +71,10 @@ install: build
 	install -p -m 644 $(FILES) $(DESTDIR)/share/beakerlib
 	install -p profiling.sh $(DESTDIR)/share/beakerlib
 	install -p -m 644 dictionary.vim $(DESTDIR)/share/beakerlib
+
+# Patch installed beakerlib.sh
+	@$(call portable_sed, "s|declare -r __INTERNAL_GETOPT_CMD=\"getopt\"|declare -r __INTERNAL_GETOPT_CMD=\"${GETOPT_CMD}\"|", $(DESTDIR)/share/beakerlib/beakerlib.sh)
+	@$(call portable_sed, "s|declare -r __INTERNAL_READLINK_CMD=\"readlink\"|declare -r __INTERNAL_READLINK_CMD=\"${READLINK_CMD}\"|", $(DESTDIR)/share/beakerlib/beakerlib.sh)
 
 	install -p -m 644 xslt-templates/* $(DESTDIR)/share/beakerlib/xslt-templates
 

--- a/src/beakerlib.sh
+++ b/src/beakerlib.sh
@@ -31,6 +31,10 @@
 #   Boston, MA 02110-1301, USA.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Command aliases for compatibilities. Set them by replacing this string through the Makefile interface
+declare -r __INTERNAL_GETOPT_CMD="getopt"
+
 __INTERNAL_SOURCED=${__INTERNAL_SOURCED-}
 echo "${__INTERNAL_SOURCED}" | grep -qF -- " ${BASH_SOURCE} " && return || __INTERNAL_SOURCED+=" ${BASH_SOURCE} "
 

--- a/src/beakerlib.sh
+++ b/src/beakerlib.sh
@@ -34,6 +34,7 @@
 
 # Command aliases for compatibilities. Set them by replacing this string through the Makefile interface
 declare -r __INTERNAL_GETOPT_CMD="getopt"
+declare -r __INTERNAL_READLINK_CMD="readlink"
 
 __INTERNAL_SOURCED=${__INTERNAL_SOURCED-}
 echo "${__INTERNAL_SOURCED}" | grep -qF -- " ${BASH_SOURCE} " && return || __INTERNAL_SOURCED+=" ${BASH_SOURCE} "
@@ -479,7 +480,7 @@ TESTID=${TESTID-}
 JOBID=${JOBID-}
 RECIPEID=${RECIPEID-}
 BEAKERLIB_JOURNAL=${BEAKERLIB_JOURNAL-}
-export BEAKERLIB=${BEAKERLIB:-$(dirname "$(readlink -e ${BASH_SOURCE})")}
+export BEAKERLIB=${BEAKERLIB:-$(dirname "$($__INTERNAL_READLINK_CMD -e ${BASH_SOURCE})")}
 . $BEAKERLIB/storage.sh
 . $BEAKERLIB/infrastructure.sh
 . $BEAKERLIB/journal.sh

--- a/src/infrastructure.sh
+++ b/src/infrastructure.sh
@@ -219,7 +219,7 @@ Returns 0 if mounting the share was successful.
 
 rlMount() {
     local OPTIONS=''
-    local GETOPT=$(getopt -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
+    local GETOPT=$($__INTERNAL_GETOPT_CMD -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
     while true; do
       case $1 in
         --) shift; break; ;;
@@ -288,7 +288,7 @@ options, 2 otherwise.
 
 rlCheckMount() {
     local MNTOPTS=''
-    local GETOPT=$(getopt -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
+    local GETOPT=$($__INTERNAL_GETOPT_CMD -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
     while true; do
       case $1 in
         --) shift; break; ;;
@@ -383,7 +383,7 @@ the mountpoint uses all the given options.
 
 rlAssertMount() {
     local MNTOPTS=''
-    local GETOPT=$(getopt -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
+    local GETOPT=$($__INTERNAL_GETOPT_CMD -o o: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
     while true; do
       case $1 in
         --) shift; break; ;;
@@ -461,7 +461,7 @@ Returns 0 if success.
 =cut
 
 rlHash() {
-  local GETOPT=$(getopt -o a: -l decode,algorithm:,stdin -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
+  local GETOPT=$($__INTERNAL_GETOPT_CMD -o a: -l decode,algorithm:,stdin -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)); eval set -- "$GETOPT"
   local decode=0 alg="$rlHashAlgorithm" stdin=0
   while true; do
     case $1 in
@@ -637,7 +637,7 @@ rlFileBackup() {
     local IFS
 
     # getopt will cut off first long opt when no short are defined
-    OPTS=$(getopt -o "." -l "clean,namespace:,no-missing-ok,missing-ok" -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    OPTS=$($__INTERNAL_GETOPT_CMD -o "." -l "clean,namespace:,no-missing-ok,missing-ok" -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     [ $? -ne 0 ] && return 1
 
     eval set -- "$OPTS"
@@ -815,7 +815,7 @@ rlFileRestore() {
     local IFS
 
     # getopt will cut off first long opt when no short are defined
-    OPTS=$(getopt -o "n:" -l "namespace:" -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    OPTS=$($__INTERNAL_GETOPT_CMD -o "n:" -l "namespace:" -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     [ $? -ne 0 ] && return 1
 
     eval set -- "$OPTS"

--- a/src/infrastructure.sh
+++ b/src/infrastructure.sh
@@ -713,7 +713,7 @@ rlFileBackup() {
         file="$(echo "$file" | sed "s|^\([^/]\)|$PWD/\1|" | sed 's|/$||')"
         # follow symlinks in parent dir
         path="$(dirname "$file")"
-        path="$(readlink -n -m "$path")"
+        path="$($__INTERNAL_READLINK_CMD -n -m "$path")"
         file="$path/$(basename "$file")"
 
         # bail out if the file does not exist

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -114,15 +114,15 @@ __INTERNAL_extractOrigin(){
 
   if [ ! -e "$0" ]
   then
-    SOURCE="$( readlink -f . )"
+    SOURCE="$( $__INTERNAL_READLINK_CMD -f . )"
   else
-    SOURCE="$( readlink -f $0 )"
+    SOURCE="$( $__INTERNAL_READLINK_CMD -f $0 )"
   fi
 
   local DIR="$( dirname "$SOURCE" )"
   while [ -h "$SOURCE" ]
   do
-      SOURCE="$(readlink -f "$SOURCE")"
+      SOURCE="$($__INTERNAL_READLINK_CMD -f "$SOURCE")"
       [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
       DIR="$( cd -P "$( dirname "$SOURCE"  )" && pwd )"
   done

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -517,7 +517,7 @@ rlFileSubmit -s '_' /etc/passwd -> etc_passwd
 =cut
 
 rlFileSubmit() {
-    GETOPT=$(getopt -o s: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    GETOPT=$(__INTERNAL_GETOPT_CMD -o s: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     eval set -- "$GETOPT"
 
     SEPARATOR='-'

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -551,7 +551,7 @@ rlFileSubmit() {
             ALIAS=$(echo $ALIAS | tr '/' "$SEPARATOR" | sed "s/^${SEPARATOR}*//")
         fi
         rlLogInfo "Sending $FILE as $ALIAS"
-        ln -s "$(readlink -f $FILE)" "$TMPDIR/$ALIAS"
+        ln -s "$($__INTERNAL_READLINK_CMD -f $FILE)" "$TMPDIR/$ALIAS"
 
         if [ -z "$BEAKERLIB_COMMAND_SUBMIT_LOG" ]
         then

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -340,7 +340,7 @@ rlAssertBinaryOrigin() {
     {
         status=1
         # expand symlinks (if any)
-        local BINARY=$(readlink -f $FULL_CMD)
+        local BINARY=$($__INTERNAL_READLINK_CMD -f $FULL_CMD)
 
         # get the rpm owning the binary
         local BINARY_RPM=$(rpm -qf --qf="%{name}\n" $BINARY | uniq)

--- a/src/storage.sh
+++ b/src/storage.sh
@@ -46,7 +46,7 @@ __INTERNAL_STORAGE_DEFAULT_NAMESPACE="GENERIC"
 __INTERNAL_ST_OPTION_PARSER='
   local namespace="$__INTERNAL_STORAGE_DEFAULT_NAMESPACE"
   local section="$__INTERNAL_STORAGE_DEFAULT_SECTION"
-  local GETOPT=$(getopt -o : -l namespace:,section: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)) || return 126
+  local GETOPT=$($__INTERNAL_GETOPT_CMD -o : -l namespace:,section: -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done)) || return 126
   eval set -- "$GETOPT"
   while true; do
     case $1 in

--- a/src/synchronisation.sh
+++ b/src/synchronisation.sh
@@ -26,9 +26,10 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 echo "${__INTERNAL_SOURCED}" | grep -qF -- " ${BASH_SOURCE} " && return || __INTERNAL_SOURCED+=" ${BASH_SOURCE} "
 
-getopt -T || ret=$?
+$__INTERNAL_GETOPT_CMD -T || ret=$?
 if [ ${ret:-0} -ne 4 ]; then
     echo "ERROR: Non enhanced getopt version detected" 1>&2
+    echo "getopt command used: $__INTERNAL_GETOPT_CMD" 1>&2
     exit 1
 fi
 
@@ -118,7 +119,7 @@ __INTERNAL_wait_for_cmd() {
     shift 1
 
     # that is the GNU extended getopt syntax!
-    local TEMP=$(getopt -o t:p:m:d:r: -n '$routine_name' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    local TEMP=$($__INTERNAL_GETOPT_CMD -o t:p:m:d:r: -n '$routine_name' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     if [[ $? != 0 ]] ; then
         rlLogError "$routine_name: Can't parse command options, terminating..."
         return 127
@@ -348,7 +349,7 @@ rlWaitForFile() {
     local file=""
 
     # that is the GNU extended getopt syntax!
-    local TEMP=$(getopt -o t:p:d: -n 'rlWaitForFile' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    local TEMP=$($__INTERNAL_GETOPT_CMD -o t:p:d: -n 'rlWaitForFile' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     if [[ $? != 0 ]] ; then
         rlLogError "rlWaitForSocket: Can't parse command options, terminating..."
         return 127
@@ -440,7 +441,7 @@ rlWaitForSocket(){
     local remote=false
 
     # that is the GNU extended getopt syntax!
-    local TEMP=$(getopt -o t:p:d: --longoptions close,remote -n 'rlWaitForSocket' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    local TEMP=$($__INTERNAL_GETOPT_CMD -o t:p:d: --longoptions close,remote -n 'rlWaitForSocket' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     if [[ $? != 0 ]] ; then
         rlLogError "rlWaitForSocket: Can't parse command options, terminating..."
         return 127
@@ -531,7 +532,7 @@ Signal used to kill the process, optional SIGTERM by default.
 #'
 rlWait() {
     # that is the GNU extended getopt syntax!
-    local TEMP=$(getopt -o t:s: -n 'rlWait' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    local TEMP=$($__INTERNAL_GETOPT_CMD -o t:s: -n 'rlWait' -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     if [[ $? != 0 ]]; then
         rlLogError "rlWait: Can't parse command options, terminating..."
         return 128

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -759,7 +759,7 @@ B<Warning:> using C<unbuffer> tool is now disabled because of bug 547686.
 #'
 
 rlRun() {
-    local __INTERNAL_rlRun_GETOPT=$(getopt -o lcts -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
+    local __INTERNAL_rlRun_GETOPT=$($__INTERNAL_GETOPT_CMD -o lcts -- "$@" 2> >(while read -r line; do rlLogError "$FUNCNAME: $line"; done))
     eval set -- "$__INTERNAL_rlRun_GETOPT"
 
     local __INTERNAL_rlRun_DO_LOG=false


### PR DESCRIPTION
Addressing the packaging issue in: https://github.com/Homebrew/homebrew-core/pull/164352#discussion_r1520071204

- [x] Alias `getopt` to `GETOPT_CMD`
- [x] Alias `readlink` to `READLINK_CMD`
- [x] Add a makefile interface to `sed` these functions. I am not proficient in writing Makefiles manually, can someone help for this?

Hopefully the CI can catch any issues with aliasing

Depends-on: #171
Homebrew runner: https://github.com/LecrisUT/homebrew-tmt/pull/1 (I'll try to keep it in sync with this PR)