### PR TITLE
Remove `ref-names` form .git_archival.txt

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=?[0-9.]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
This is needed to make the git archive source reproducible. See https://github.com/pypa/setuptools_scm/pull/1033

This should be merged before any new release is cut