### PR TITLE
use --srpm for source download if available

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,10 @@ files_to_sync:
 upstream_package_name: beakerlib
 downstream_package_name: beakerlib
 
+actions:
+    changelog-entry:
+      - "bash -c 'rpm -q --qf \"%{CHANGELOGTEXT}\n\" --specfile dist/beakerlib.spec 2> /dev/null | grep -v \"(none)\"'"
+
 jobs:
   - job: copr_build
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,7 @@ jobs:
       - fedora-all
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
       - epel-6
       - epel-all
 
@@ -30,12 +31,22 @@ jobs:
       - fedora-all-aarch64
       - centos-stream-8-x86_64
       - centos-stream-8-aarch64
+      - centos-stream-8-s390x
+      - centos-stream-8-ppc64le
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+      - centos-stream-9-s390x
+      - centos-stream-9-ppc64le
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
+      - centos-stream-10-s390x
+      - centos-stream-10-ppc64le
       - epel-6-x86_64
       - epel-6-aarch64
       - epel-all-x86_64
       - epel-all-aarch64
+      - epel-all-s390x
+      - epel-all-ppc64le
 
   - job: tests
     trigger: pull_request

--- a/dist/beakerlib.spec
+++ b/dist/beakerlib.spec
@@ -69,20 +69,20 @@ Patch3: python-platform.patch
 %autosetup -N
 %if 0%{?fedora}
 # Patch0: bugzilla-links.patch
-%patch0 -p1
+%patch -P 0 -p1
 %else
 # rhel
 # Patch1: bugzilla-links-epel.patch
-%patch1 -p1
+%patch -P 1 -p1
 %endif
 
 %if 0%{?fedora}
 # Patch2: python3.patch
-%patch2 -p1
+%patch -P 2 -p1
 %endif
 %if 0%{?rhel} > 7
 # Patch3: python-platform.patch
-%patch3 -p1
+%patch -P 3 -p1
 %endif
 
 

--- a/src/rpms.sh
+++ b/src/rpms.sh
@@ -1088,10 +1088,15 @@ __INTERNAL_rpmGetWithYumDownloader() {
         fi
     fi
 
+    [[ -n "$source" ]] && {
+      $tool --help | grep -q -- '--srpm' && source='--srpm'
+    }
+
     rlLogDebug "${FUNCNAME}(): Trying '$tool' to download $package"
     local tmp
     if tmp=$(mktemp -d); then
         rlLogDebug "$FUNCNAME(): downloading package to tmp dir '$tmp'"
+        rlLogInfo "running '$tool $quiet -y $source $package'"
         ( cd $tmp; $tool $quiet -y $source $package >&2 ) || {
             rlLogError "'$tool' failed"
             rm -rf $tmp


### PR DESCRIPTION
the dnf5 renamed --source to --srpm, thus we need to use the new name