### PR TITLE
do not block rlJournalPrint on journal.xml creation failure

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -391,7 +391,7 @@ Example:
 
 # cat generated text version
 rlJournalPrint(){
-  __INTERNAL_JournalXMLCreate
+  __INTERNAL_JournalXMLCreate || return $?
   if [[ "$1" == "raw" ]]; then
     cat "$__INTERNAL_BEAKERLIB_JOURNAL"
   else


### PR DESCRIPTION
if the journal.xml was not created, the rlJournalPring function got stuck on basically
`cat -`
