### PR TITLE
Ensure the dashes are removed from the test name prefix

### DIFF
--- a/src/journal.sh
+++ b/src/journal.sh
@@ -680,9 +680,9 @@ rljClosePhase(){
     tail -n +$((__INTERNAL_PHASE_TXTLOG_START+1)) "$__INTERNAL_BEAKERLIB_JOURNAL_TXT" > $logfile
 
     # Replace all non-alphanumeric characters with dashes in the test name.
-    # Also make sure the test name does not start with dashes and ensure the
-    # dashes are not repeated.
-    rlReport "$(echo "${name//[^[:alnum:]]/-}" | sed 's/^-\+//' | tr -s '-')" "$result" "$score" "$logfile"
+    # Also make sure the test name does not start/end with dashes and ensure
+    # the dashes are not repeated.
+    rlReport "$(echo "${name//[^[:alnum:]]/-}" | sed 's/^-\+//' | sed 's/-\+$//' | tr -s '-')" "$result" "$score" "$logfile"
     rm -f $logfile
 
     # Reset of state variables

--- a/src/journal.sh
+++ b/src/journal.sh
@@ -678,7 +678,11 @@ rljClosePhase(){
                             "($name)"
     local logfile="$(mktemp)"
     tail -n +$((__INTERNAL_PHASE_TXTLOG_START+1)) "$__INTERNAL_BEAKERLIB_JOURNAL_TXT" > $logfile
-    rlReport "$(echo "${name//[^[:alnum:]]/-}" | tr -s '-')" "$result" "$score" "$logfile"
+
+    # Replace all non-alphanumeric characters with dashes in the test name.
+    # Also make sure the test name does not start with dashes and ensure the
+    # dashes are not repeated.
+    rlReport "$(echo "${name//[^[:alnum:]]/-}" | sed 's/^-\+//' | tr -s '-')" "$result" "$score" "$logfile"
     rm -f $logfile
 
     # Reset of state variables

--- a/src/journal.sh
+++ b/src/journal.sh
@@ -682,7 +682,7 @@ rljClosePhase(){
     # Replace all non-alphanumeric characters with dashes in the test name.
     # Also make sure the test name does not start/end with dashes and ensure
     # the dashes are not repeated.
-    rlReport "$(echo "${name//[^[:alnum:]]/-}" | sed 's/^-\+//' | sed 's/-\+$//' | tr -s '-')" "$result" "$score" "$logfile"
+    rlReport "$(echo "${name//[^[:alnum:]]/-}" | sed -r 's/-+/-/g;s/^-//;s/-$//')" "$result" "$score" "$logfile"
     rm -f $logfile
 
     # Reset of state variables

--- a/src/test/journalTest.sh
+++ b/src/test/journalTest.sh
@@ -365,5 +365,8 @@ test_phaseNameIn_rlReport(){
     journalReset
 
     silentIfNotDebug "rlPhaseStartTest '//some/-phase//na--me-'"
-    assertTrue "Phase name is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^some-phase-na-me '"
+    assertTrue "Phase name with slashes is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^some-phase-na-me '"
+
+    silentIfNotDebug "rlPhaseStartTest '\$so\$me<->phase?!*na--me/-'"
+    assertTrue "Phase name with special chars is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^so-me-phase-na-me '"
 }

--- a/src/test/journalTest.sh
+++ b/src/test/journalTest.sh
@@ -365,5 +365,5 @@ test_phaseNameIn_rlReport(){
     journalReset
 
     silentIfNotDebug "rlPhaseStartTest '//some/-phase//na--me-'"
-    assertTrue "Phase name is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^some-phase-na-me- '"
+    assertTrue "Phase name is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^some-phase-na-me '"
 }

--- a/src/test/journalTest.sh
+++ b/src/test/journalTest.sh
@@ -359,3 +359,11 @@ test_packageLoggingGuess() {
   assertTrue "rlJournalStart survives garbage in TEST" "rlJournalStart"
   assertFalse "No <pkgdetails> tag when TEST is garbage" "rlJournalPrint | grep -q '<pkgdetails>'"
 }
+
+test_phaseNameIn_rlReport(){
+    export BEAKERLIB_COMMAND_REPORT_RESULT=echo
+    journalReset
+
+    silentIfNotDebug "rlPhaseStartTest '//some/-phase//na--me-'"
+    assertTrue "Phase name is correctly converted when passing value to rlReport in rlPhaseEnd" "rlPhaseEnd | grep '^some-phase-na-me- '"
+}


### PR DESCRIPTION
This PR ensures the dashes are removed from the prefix of the test name (phase name) when calling the `rlReport`.

Commands located in the `BEAKERLIB_COMMAND_REPORT_RESULT` variable can badly handle these dashes (e.g. as program arguments when parsing with getopts):
- https://github.com/beakerlib/beakerlib/blob/cfa801fb175fef1e47b8552d6cf6efcb51df7227/src/testing.sh#L1076

We should also consider adding `--` after the `$BEAKERLIB_COMMAND_REPORT_RESULT` command call to enforce the handling of these arguments as positional. But [we are not sure](https://github.com/teemtee/tmt/issues/3333#issuecomment-2451850172) whether `rstrnt-report-result` or `rhts-report-result`  would handle it as expected:

```
$BEAKERLIB_COMMAND_REPORT_RESULT -- "$testname" "$result" "$logfile" "$score" || rlLogError "rlReport: Failed to report the result"
```

Related to:
- https://github.com/teemtee/tmt/issues/3333

### TODOs:
- [x] Marked as draft - I still need to test it together with tmt and `tmt-report-result` script.
- [x] Add some tests