### PR TITLE
libraries: allow nick without url nor path

### DIFF
--- a/dist/beakerlib.spec
+++ b/dist/beakerlib.spec
@@ -144,7 +144,7 @@ Files for syntax highlighting BeakerLib tests in VIM editor
 - fixed rlIsRHELLike on systems without /etc/os-release, e.g. RHEL-6
 - some minor updates
 
-* Wed Nov 11 2024 Dalibor Pospisil <dapospis@redhat.com> - 1.31.3-1
+* Mon Nov 11 2024 Dalibor Pospisil <dapospis@redhat.com> - 1.31.3-1
 - Ensure the dashes are removed from the test name prefix, by seberm
 
 * Wed Jul 17 2024 Dalibor Pospisil <dapospis@redhat.com> - 1.31.2-1

--- a/src/libraries.sh
+++ b/src/libraries.sh
@@ -73,20 +73,23 @@ __INTERNAL_extractRequires(){
       lib_url="${yaml[$i.url]%/}"
       lib_path="${yaml[$i.path]%/}"
       [[ -z "$type" || "$type" == "library" ]] && [[ -n "$lib_name" ]] && {
-        if [[ -n "$lib_url" ]]; then
-          [[ "$lib_url" =~ .*/([^/]+)$ ]] && {
-            # try to process library in COMPONENT/LIBNAME format
-            component="${BASH_REMATCH[1]%.git}"
-            [[ -n "$lib_nick" ]] && component="$lib_nick"
-            __INTERNAL_LIBRARY_DEPS+=" ${component}${lib_path}${lib_name}"
-          }
+        if [[ -n "$lib_nick" ]]; then
+          component="$lib_nick"
+          __INTERNAL_LIBRARY_DEPS+=" ${component}${lib_name}"
         else
-          [[ "$lib_path" =~ .*/([^/]+)$ ]] && {
-            # try to process library in the <last part of path>/LIBNAME format
-            component="${BASH_REMATCH[1]}"
-            [[ -n "$lib_nick" ]] && component="$lib_nick"
-            __INTERNAL_LIBRARY_DEPS+=" ${component}${lib_name}"
-          }
+          if [[ -n "$lib_url" ]]; then
+            [[ "$lib_url" =~ .*/([^/]+)$ ]] && {
+              # try to process library in COMPONENT/LIBNAME format
+              component="${BASH_REMATCH[1]%.git}"
+              __INTERNAL_LIBRARY_DEPS+=" ${component}${lib_path}${lib_name}"
+            }
+          else
+            [[ "$lib_path" =~ .*/([^/]+)$ ]] && {
+              # try to process library in the <last part of path>/LIBNAME format
+              component="${BASH_REMATCH[1]}"
+              __INTERNAL_LIBRARY_DEPS+=" ${component}${lib_name}"
+            }
+          fi
         fi
       }
     done

--- a/src/test/rpmsTest.sh
+++ b/src/test/rpmsTest.sh
@@ -208,7 +208,7 @@ test_rlRpmDownload(){
 test_rlRpmInstall(){
         rpm_string=$(rpm -q beakerlib | head -n1)
 
-	parsed_string=$(echo "$rpm_string" | sed -r 's/^beakerlib-([0-9]+\.[0-9]+\.[0-9]+)-([^-]+)\.([^-]+)$/v=\1 d=\2 a=\3/')
+	parsed_string=$(echo "$rpm_string" | sed -r 's/^beakerlib-([0-9.]+)-(.+)\.([^.]+)$/v=\1 d=\2 a=\3/')
 
 	eval "$parsed_string"
 


### PR DESCRIPTION
In order to be able to find a library referenced by the **name** only while explicitly importing using the component/name format the **nick** can be used to match the **component** from the test code.