### PR TITLE
synchronisation.sh: fix rlWaitForSocket for unix sockets

### DIFF
--- a/src/synchronisation.sh
+++ b/src/synchronisation.sh
@@ -485,7 +485,7 @@ rlWaitForSocket(){
     else
         local sock_type="x"  # UNIX sockets
         $remote && field=7
-        local grep_opt="^$socket\s"
+        local grep_opt="^$socket\$"
     fi
     local cmd="ss -nl -$sock_type | tail -n+2 | awk '{print \$$field}' | grep -E $grep_opt >/dev/null"
 

--- a/src/test/loggingTest.sh
+++ b/src/test/loggingTest.sh
@@ -120,16 +120,15 @@ test_rlPhaseStartShortcuts(){
 }
 
 test_oldMetrics(){
-    rlPhaseStartTest &> /dev/null
     assertTrue "rlLogHighMetric is marked as deprecated" \
         "rlLogHighMetric MTR-HIGH-OLD 1 2>&1 >&- |grep -q deprecated"
     assertTrue "rlLogLowMetric is marked as deprecated" \
         "rlLogLowMetric MTR-LOW-OLD 1 2>&1 >&- |grep -q deprecated"
 }
+
 test_rlShowPkgVersion(){
     assertTrue "rlShowPkgVersion is marked as deprecated" \
         "rlShowPkgVersion 2>&1 >&- |grep -q obsoleted"
-    rlPhaseEnd
 }
 
 

--- a/src/test/synchronisationTest.sh
+++ b/src/test/synchronisationTest.sh
@@ -34,6 +34,26 @@ test_rlWaitForSocketPositive() {
     rm -rf $test_dir
 }
 
+test_rlWaitForSocketPositiveUnixSocket() {
+    local test_dir=$(mktemp -d /tmp/beakerlib-test-XXXXXX)
+
+    (sleep 5; /usr/bin/ncat -l -U "$test_dir/test.sock" > "$test_dir/out") &
+    local bg_pid=$!
+
+    silentIfNotDebug "rlWaitForSocket $test_dir/test.sock"
+    local ret=$?
+    assertTrue "Check if rlWaitForSocket return 0 when socket is opened" "[[ $ret -eq 0 ]]"
+
+    silentIfNotDebug "echo 'hello world' | /usr/bin/ncat -U $test_dir/test.sock"
+
+    kill -s SIGKILL $bg_pid 2>/dev/null 1>&2
+    wait $bg_pid 2>/dev/null 1>&2
+
+    assertTrue "Check if data was transferred" "grep 'hello world' $test_dir/out"
+
+    rm -rf $test_dir
+}
+
 test_rlWaitForSocketClose() {
     local test_dir=$(mktemp -d /tmp/beakerlib-test-XXXXXX)
 


### PR DESCRIPTION
This has been broken since 81929b59649a12b670ac85929a8f90eeb48aab2a as
we now use awk to "grep" only the field with the socket path which
doesn't have the trailing space.