### PR TITLE
Bash grouping is needed for matching multiple versions of OS with ope…

### DIFF
--- a/src/testing.sh
+++ b/src/testing.sh
@@ -1540,7 +1540,7 @@ rlIsOSLike() {
 =item VERSION_SPEC
 
 Parameter is based on VERSION_ID in /etc/os-release.
-It consists of either C<major> or C<major>.C<minor> refering to a particular release.
+It consists of either C<major> or C<major>.C<minor> referring to a particular release.
 
 It accepts multiple arguments separated by space (8.1 8.2 8.3 9).
 
@@ -1586,6 +1586,11 @@ Note:
     rlIsOSVersion 7 && rlIsOSVersion '<7.5' || rlIsOSVersion 8 && rlIsOSVersion '<8.5'
 
   This returns 0 when running distribution less than 7.5 and less then 8.5, but not 7.9 (nor 6.9).
+
+  Bash command grouping is needed due to operators priority, example uses curly brackets to run in the same shell
+  https://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html
+
+    { rlIsOSVersion 7 && rlIsOSVersion '<7.5';} || { rlIsOSVersion 8 && rlIsOSVersion '<8.5';}
 
 =cut
 #'

--- a/src/testing.sh
+++ b/src/testing.sh
@@ -1583,14 +1583,12 @@ Note:
   So if you want to construct a condition for a distribution <7.5 within the major 7 or
   a distribution <8.5 within the major 8 you actually need to use following construct:
 
-    rlIsOSVersion 7 && rlIsOSVersion '<7.5' || rlIsOSVersion 8 && rlIsOSVersion '<8.5'
+    rlIsOSVersion 7 && rlIsOSVersion '<7.5' || { rlIsOSVersion 8 && rlIsOSVersion '<8.5'; }
 
   This returns 0 when running distribution less than 7.5 and less then 8.5, but not 7.9 (nor 6.9).
 
-  Bash command grouping is needed due to operators priority, example uses curly brackets to run in the same shell
+  Note, the bash command grouping might needed due to operators priority, example uses curly brackets to run in the same shell
   https://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html
-
-    { rlIsOSVersion 7 && rlIsOSVersion '<7.5';} || { rlIsOSVersion 8 && rlIsOSVersion '<8.5';}
 
 =cut
 #'


### PR DESCRIPTION
There is not working Bash matching based on operators for multiple versions. Therefore Bash brouping is needed to work properly.
I was unable to exclude version `10.2` based on current documentation using `rlIsRHEL 9 && rlIsRHEL '>=9.9' || rlIsRHEL 10 && rlIsRHEL '>=10.3'` however bash grouping start working properly for exclusion of version `9.8` and `10.2` as well as properly match versions `9.9` and `10.3`