### PR TITLE
beakerlib.sh: skip plugin sourcing when plugins dir is empty

### DIFF
--- a/src/beakerlib.sh
+++ b/src/beakerlib.sh
@@ -500,6 +500,7 @@ if [ -d $BEAKERLIB/plugins/ ] ; then
     __INTERNAL_IFS_OLD="$IFS"
     unset IFS
     for __INTERNAL_beakerlib_source_plugin in $BEAKERLIB/plugins/*.sh ; do
+        [ -e "$__INTERNAL_beakerlib_source_plugin" ] || continue
         . $__INTERNAL_beakerlib_source_plugin
     done
     IFS="$__INTERNAL_IFS_OLD"


### PR DESCRIPTION
When `$BEAKERLIB/plugins/` exists but contains no `.sh` files, the glob `$BEAKERLIB/plugins/*.sh` does not expand and is passed literally to the source builtin, producing:

```
/usr/share/beakerlib/beakerlib.sh: line 505: /usr/share/beakerlib/plugins/*.sh: No such file or directory
```

This aborts library loading and makes tests fail in a way that cannot be parsed (`TestResults FileError`), even though the test itself is fine. Guard the loop body with an existence check so a non-matching glob is skipped instead of sourced.

We hit this with an user, and seems a valid corner case to nicely handle.